### PR TITLE
Add new cve branch and allow LPs extending existing ones without changing the original LP's name

### DIFF
--- a/klpbuild/ibs.py
+++ b/klpbuild/ibs.py
@@ -562,9 +562,13 @@ class IBS(Config):
             stderr=subprocess.STDOUT,
         )
 
-        # Check if the directory related to this bsc exists
+        # Check if the directory related to this bsc exists.
+        # Otherwise only warn the caller about this fact.
+        # This scenario can occur in case of LPing function that is already
+        # part of different LP in which case we modify the existing one.
         if self.lp_name not in os.listdir(code_path):
-            raise RuntimeError(f"Directory {self.lp_name} not found on branch {branch}")
+            logging.warning(f"Warning: Directory {self.lp_name} not found on branch {branch}")
+
 
         # Fix RELEASE version
         with open(Path(code_path, "scripts", "release-version.sh"), "w") as f:

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -40,6 +40,7 @@ class GitHelper(Config):
             "15.5": "SLE15-SP5",
             "15.5rt": "SLE15-SP5-RT",
             "cve-5.3": "cve/linux-5.3-LTSS",
+            "cve-5.14": "cve/linux-5.14-LTSS",
         }
 
         # Filter only the branches related to this BSC


### PR DESCRIPTION
ksrc.py: Add cve/linux-5.14-LTSS branch as a primary branch receiving CVE fixes for 5.14 based kernels
ibs.py: Allow to build LP without having a directory with expected bsc# to support LPs extending already existing ones
