### PR TITLE
extractor: Add filelocking support for srcdir

### DIFF
--- a/klpbuild/extractor.py
+++ b/klpbuild/extractor.py
@@ -31,7 +31,7 @@ class Extractor(Config):
     def __init__(self, lp_name, lp_filter, apply_patches, app, avoid_ext, workers=4):
         super().__init__(lp_name, lp_filter)
 
-        self.sdir_lock = FileLock(Path(self.get_data_dir("x86_64"), "sdir.lock"))
+        self.sdir_lock = FileLock(Path(self.get_data_dir(utils.ARCH), "sdir.lock"))
         self.sdir_lock.acquire()
 
         if not self.lp_path.exists():

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setuptools.setup(
         "natsort",
         "osc-tiny",
         "requests",
+        "filelock"
     ],
 )


### PR DESCRIPTION
This patch adds the required support for sharing the same data folder with multiple instances of klp-build.

The filelock library implements a multiplatform code to create an additional file as a lock to synchronize a folder between multiple processes.

Even though Python does not call "destructor" __del__ in case of an unhandled exception, the library itself takes care of unhandled files, so this location for releasing the lock seems to be enough.