### PR TITLE
Add support for tests files in directories

### DIFF
--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -299,6 +299,26 @@ class Config:
             return Path(self.get_data_dir(arch), "lib", "modules", f"{self.get_cs_kernel(cs)}-{self.get_ktype(cs)}")
         return self.get_data_dir(arch)
 
+    def get_tests_path(self):
+        self.kgraft_tests_path = Path(Path().home(), "kgr", "kgraft-patches_testscripts")
+        if not self.kgraft_tests_path.is_dir():
+            raise RuntimeError(f"Couldn't find {self.kgraft_tests_path}")
+
+        test_sh = Path(self.kgraft_tests_path, f"{self.lp_name}_test_script.sh")
+        test_dir_sh = Path(self.kgraft_tests_path, f"{self.lp_name}/test_script.sh")
+
+        if test_sh.is_file():
+            test_src = test_sh
+        elif test_dir_sh.is_file():
+            # For more complex tests we support using a directory containing
+            # as much files as needed. A `test_script.sh` is still required
+            # as an entry point.
+            test_src = Path(os.path.dirname(test_dir_sh))
+        else:
+            raise RuntimeError(f"Couldn't find {test_sh} or {test_dir_sh}")
+
+        return test_src
+
     def flush_cs_file(self):
         with open(self.cs_file, "w") as f:
             f.write(json.dumps(self.codestreams, indent=4))

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -121,29 +121,24 @@ class GitHelper(Config):
         patches_dir = Path(self.lp_path, "patches")
         shutil.rmtree(patches_dir, ignore_errors=True)
 
-        # Ensure that a testfile was created before preparing the patches
-        kgraft_tests_path = Path(Path().home(), "kgr", "kgraft-patches_testscripts")
-        test_sh = Path(kgraft_tests_path, f"{self.lp_name}_test_script.sh")
-        if not test_sh.is_file():
-            logging.warning(f"Test file {test_sh} not created.")
-        else:
-            subprocess.check_output(
-                [
-                    "/usr/bin/git",
-                    "-C",
-                    str(kgraft_tests_path),
-                    "format-patch",
-                    "-1",
-                    f"{test_sh}",
-                    "--cover-letter",
-                    "--start-number",
-                    "1",
-                    "--subject-prefix",
-                    f"PATCH {ver}",
-                    "--output-directory",
-                    f"{patches_dir}",
-                ]
-            )
+        test_src = self.get_tests_path()
+        subprocess.check_output(
+            [
+                "/usr/bin/git",
+                "-C",
+                str(self.kgraft_tests_path),
+                "format-patch",
+                "-1",
+                f"{test_src}",
+                "--cover-letter",
+                "--start-number",
+                "1",
+                "--subject-prefix",
+                f"PATCH {ver}",
+                "--output-directory",
+                f"{patches_dir}",
+            ]
+        )
 
         # Filter only the branches related to this BSC
         for branch in self.branches:

--- a/scripts/run-kgr-test.sh
+++ b/scripts/run-kgr-test.sh
@@ -14,20 +14,21 @@ fi
 # directory of the current script is the bsc number
 bsc=$(basename "$(pwd)")
 
-TEST_SCRIPT="repro/${bsc}_test_script.sh"
-if [ ! -f "$TEST_SCRIPT" ]; then
-	echo "Missing $TEST_SCRIPT. Aborting."
-	exit 1
-fi
-
 # Remove any previous test output
 rm -rf tests.out/*
 
 # If the test has multiple files, it should be contained in a directory under
 # repro/$bsc, otherwise it's only one file under repro
-CONF_IN=repro/$bsc/config.in
-if [ ! -f "$CONF_IN" ]; then
-	CONF_IN=repro/${bsc}_config.in
+TEST_SCRIPT=repro/${bsc}_test_script.sh
+CONF_IN=repro/${bsc}_config.in
+if [ -d "repro/$bsc" ]; then
+	TEST_SCRIPT=repro/${bsc}/test_script.sh
+	CONF_IN=repro/$bsc/config.in
+fi
+
+if [ ! -f "$TEST_SCRIPT" ]; then
+	echo "Missing $TEST_SCRIPT. Aborting."
+	exit 1
 fi
 
 # Check multiple places where an updated version of the VMs can be found


### PR DESCRIPTION
Up until now we only supported having a single test file per livepatch, but in some cases a more complex environment is required. For that reason a directory per livepatch will be allowed, containing any files needed to sucessfully test the lp. A `test_script.sh` file will still be used as an entry point at runtime.