### PR TITLE
Do not create a second time the ".config"

### DIFF
--- a/klpbuild/ibs.py
+++ b/klpbuild/ibs.py
@@ -200,9 +200,6 @@ class IBS(Config):
                 vmlinux_path = Path(self.get_data_dir(arch), "boot")
                 subprocess.check_output(rf'find {vmlinux_path} -name "*gz" -exec gzip -d -f {{}} \;', shell=True)
 
-            # Use the SLE .config
-            shutil.copy(self.get_cs_boot_file(cs, ".config"), Path(self.get_odir(cs), ".config"))
-
             # Recreate the build link to enable us to test the generated LP
             mod_path = Path(self.get_mod_path(cs, ARCH), "build")
             mod_path.unlink()


### PR DESCRIPTION
Once the kernel and related binaries get extracted so does the ".config", which gets copied twice to its respective kernel src directory. Only once is good enough.

This commit also fixes a bug introduced in fb40c1c5, where the ".config" file was copied from a source with the same path as the destination, hence leading to a crash.

```
shutil.SameFileError: PosixPath('/home/fgonzalez/src/klp-data/x86_64/usr/src/linux-4.12.14-122.222-obj/x86_64/default/.config') and PosixPath('/home/fgonzalez/src/klp-data/x86_64/usr/src/linux-4.12.14-122.222-obj/x86_64/default/.config') are the same file
```