### PR TITLE
klpbuild: Copy the .config from the right place

### DIFF
--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -248,6 +248,13 @@ class Config:
     def get_ktype(self, cs):
         return "rt" if self.cs_is_rt(cs) else "default"
 
+    # The config file is copied from boot/config-<version> to linux-obj when we
+    # extract the code, and after that we always check for the config on the
+    # -obj dir. Return the original path here so we can use this function on the
+    # extraction code.
+    def get_cs_kernel_config(self, cs, arch):
+        return Path(self.get_data_dir(arch), "boot", f"config-{self.get_cs_kernel(cs)}-{self.get_ktype(cs)}")
+
     def get_cs_boot_file(self, cs, file, arch=""):
         if file == "vmlinux":
             if self.kdir:

--- a/klpbuild/ibs.py
+++ b/klpbuild/ibs.py
@@ -201,7 +201,7 @@ class IBS(Config):
                 subprocess.check_output(rf'find {vmlinux_path} -name "*gz" -exec gzip -d -f {{}} \;', shell=True)
 
             # Use the SLE .config
-            shutil.copy(self.get_cs_boot_file(cs, ".config"), Path(self.get_odir(cs), ".config"))
+            shutil.copy(self.get_cs_kernel_config(cs, ARCH), Path(self.get_odir(cs), ".config"))
 
             # Recreate the build link to enable us to test the generated LP
             mod_path = Path(self.get_mod_path(cs, ARCH), "build")


### PR DESCRIPTION
When the extraction of rpms is done we should copy the .config from the boot/config-<version>, and then future references of this file should point to linux-obj/.config, per codestreams.