### PR TITLE
config.py: Support per-user configuration file (draft)

### DIFF
--- a/klpbuild/ccp.py
+++ b/klpbuild/ccp.py
@@ -29,18 +29,7 @@ class CCP(Config):
 
         self.ccp_path = str(ccp_path)
 
-        pol_path = os.getenv("KLP_CCP_POL_PATH")
-        if pol_path and not Path(pol_path).is_dir():
-            raise RuntimeError("KLP_CCP_POL_PATH does not point to a directory")
-
-        elif not pol_path:
-            pol_path = Path(Path().home(), "kgr", "scripts", "ccp-pol")
-            if not pol_path.is_dir():
-                raise RuntimeError(
-                    "ccp-pol not found at ~/kgr/scripts/ccp-pol/.  Please set KLP_CCP_POL_PATH env var to a valid ccp-pol directory"
-                )
-
-        self.pol_path = str(pol_path)
+        self.pol_path = self.get_user_path('ccp_pol_dir')
 
         # List of symbols that are currently not resolvable for klp-ccp
         avoid_syms = [

--- a/klpbuild/ccp.py
+++ b/klpbuild/ccp.py
@@ -17,15 +17,9 @@ class CCP(Config):
 
         self.env = os.environ
 
-        # Prefer the env var to the HOME directory location
-        ccp_path = os.getenv("KLP_CCP_PATH", "")
-        if ccp_path and not Path(ccp_path).is_file():
-            raise RuntimeError("KLP_CCP_PATH does not point to a file")
-
-        elif not ccp_path:
-            ccp_path = shutil.which("klp-ccp")
-            if not ccp_path:
-                raise RuntimeError("klp-ccp not found. Aborting.")
+        ccp_path = shutil.which("klp-ccp")
+        if not ccp_path:
+            raise RuntimeError("klp-ccp not found. Aborting.")
 
         self.ccp_path = str(ccp_path)
 

--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -87,7 +87,8 @@ class Config:
         config['Paths'] = {'work_dir': workdir,
                            'data_dir': datadir,
                            '## SUSE internal use only ##': None,
-                           '#kernel_src_dir': 'kernel-src/'}
+                           '#kernel_src_dir': 'kernel-src/',
+                           '#ccp_pol_dir': 'kgr-scripts/ccp-pol/'}
 
         logging.info(f"Creating default user configuration: '{self.user_conf_file}'")
         os.makedirs(os.path.dirname(self.user_conf_file), exist_ok=True)

--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -88,7 +88,8 @@ class Config:
                            'data_dir': datadir,
                            '## SUSE internal use only ##': None,
                            '#kernel_src_dir': 'kernel-src/',
-                           '#ccp_pol_dir': 'kgr-scripts/ccp-pol/'}
+                           '#ccp_pol_dir': 'kgr-scripts/ccp-pol/',
+                           '#patches_tests_dir': 'kgraft-patches_testscripts/'}
 
         logging.info(f"Creating default user configuration: '{self.user_conf_file}'")
         os.makedirs(os.path.dirname(self.user_conf_file), exist_ok=True)
@@ -364,9 +365,7 @@ class Config:
         return self.get_data_dir(arch)
 
     def get_tests_path(self):
-        self.kgraft_tests_path = Path(Path().home(), "kgr", "kgraft-patches_testscripts")
-        if not self.kgraft_tests_path.is_dir():
-            raise RuntimeError(f"Couldn't find {self.kgraft_tests_path}")
+        self.kgraft_tests_path = self.get_user_path('patches_tests_dir')
 
         test_sh = Path(self.kgraft_tests_path, f"{self.lp_name}_test_script.sh")
         test_dir_sh = Path(self.kgraft_tests_path, f"{self.lp_name}/test_script.sh")

--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -83,9 +83,11 @@ class Config:
         datadir = Path(basedir, "data")
 
         config = configparser.ConfigParser(allow_no_value=True)
+
         config['Paths'] = {'work_dir': workdir,
                            'data_dir': datadir,
-                           '## SUSE internal use only ##': None}
+                           '## SUSE internal use only ##': None,
+                           '#kernel_src_dir': 'kernel-src/'}
 
         logging.info(f"Creating default user configuration: '{self.user_conf_file}'")
         os.makedirs(os.path.dirname(self.user_conf_file), exist_ok=True)

--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -86,6 +86,7 @@ class Config:
 
         config['Paths'] = {'work_dir': workdir,
                            'data_dir': datadir,
+                           '#patches_dir': 'kgraft-patches/',
                            '## SUSE internal use only ##': None,
                            '#kernel_src_dir': 'kernel-src/',
                            '#ccp_pol_dir': 'kgr-scripts/ccp-pol/',

--- a/klpbuild/ibs.py
+++ b/klpbuild/ibs.py
@@ -37,9 +37,7 @@ class IBS(Config):
         self.ibs_user = self.osc.username
         self.prj_prefix = f"home:{self.ibs_user}:{self.lp_name}-klp"
 
-        self.kgraft_path = Path(Path().home(), "kgr", "kgraft-patches")
-        if not self.kgraft_path.is_dir():
-            raise RuntimeError("Couldn't find ~/kgr/kgraft-patches")
+        self.kgraft_path = self.get_user_path('kgraft-patches')
 
         self.ksrc = GitHelper(self.lp_name, self.filter, False, None)
 

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -41,9 +41,9 @@ class GitHelper(Config):
 
         self.branches = []
 
-        self.kgr_patches = Path(Path().home(), "kgr", "kgraft-patches")
-        if not self.kgr_patches.is_dir():
-            logging.warning("kgraft-patches does not exists in ~/kgr")
+        self.kgr_patches = self.get_user_path('kgraft-patches', isopt=True)
+        if not self.kgr_patches:
+            logging.warning("patches_dir not found")
         else:
             # Filter only the branches related to this BSC
             repo = git.Repo(self.kgr_patches).branches
@@ -54,8 +54,8 @@ class GitHelper(Config):
     def get_cs_branch(self, cs):
         cs_sle, sp, cs_up, rt = self.get_cs_tuple(cs)
 
-        if not self.kgr_patches.is_dir():
-            logging.warning("kgraft-patches does not exists in ~/kgr")
+        if not self.kgr_patches:
+            logging.warning("patches_dir not found")
             return ""
 
         branch_name = ""
@@ -113,8 +113,8 @@ class GitHelper(Config):
         # index 1 will be the test file
         index = 2
 
-        if not self.kgr_patches.is_dir():
-            logging.warning("kgraft-patches does not exists in ~/kgr, patches will be incomplete")
+        if not self.kgr_patches:
+            logging.warning("patches_dir not found, patches will be incomplete")
 
         # Remove dir to avoid leftover patches with different names
         patches_dir = Path(self.lp_path, "patches")

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -24,9 +24,7 @@ class GitHelper(Config):
     def __init__(self, lp_name, lp_filter, kdir, data_dir):
         super().__init__(lp_name, lp_filter, kdir, data_dir)
 
-        self.kern_src = os.getenv("KLP_KERNEL_SOURCE", "")
-        if self.kern_src and not Path(self.kern_src).is_dir():
-            raise ValueError("KLP_KERNEL_SOURCE should point to a directory")
+        self.kern_src = self.get_user_path('kernel_src_dir', isopt=True)
 
         self.kernel_branches = {
             "12.5": "SLE12-SP5",
@@ -193,7 +191,7 @@ class GitHelper(Config):
 
     def get_commits(self, cve):
         if not self.kern_src:
-            logging.info("KLP_KERNEL_SOURCE not defined, skip getting SUSE commits")
+            logging.info("kernel_src_dir not found, skip getting SUSE commits")
             return {}
 
         # ensure that the user informed the commits at least once per 'project'
@@ -363,7 +361,7 @@ class GitHelper(Config):
             return []
 
         if not self.kern_src:
-            logging.info("KLP_KERNEL_SOURCE not defined, skip getting SUSE commits")
+            logging.info("kernel_src_dir not found, skip getting SUSE commits")
             return []
 
         print("Searching for already patched codestreams...")

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setuptools.setup(
         "console_scripts": ["klp-build=klpbuild.main:main"],
     },
     install_requires=[
+        "configparser",
         "cached_property",
         "GitPython",
         "lxml",

--- a/tests/test_ccp.py
+++ b/tests/test_ccp.py
@@ -13,8 +13,6 @@ from tests import utils
 
 class CcpTesting(utils.TestUtils):
     def setUp(self):
-        os.environ["KLP_KERNEL_SOURCE"] = ""
-
         logging.disable(logging.INFO)
 
     def test_detect_file_without_ftrace_support(self):

--- a/tests/test_lp_setup.py
+++ b/tests/test_lp_setup.py
@@ -14,9 +14,6 @@ from tests import utils
 
 class LpSetupTest(utils.TestUtils):
     def setUp(self):
-        # Avoid searching for patches kernels
-        os.environ["KLP_KERNEL_SOURCE"] = ""
-
         logging.disable(logging.INFO)
 
     def test_missing_conf_archs(self):

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -13,8 +13,6 @@ from tests import utils
 
 class TemplTesting(utils.TestUtils):
     def setUp(self):
-        os.environ["KLP_KERNEL_SOURCE"] = ""
-
         logging.disable(logging.INFO)
         logging.disable(logging.WARNING)
 


### PR DESCRIPTION
Add support for a per-user configuration file as the main method of configuring klp-build instead of relying on user-set environment variables.

The new implementation what basically does is:
Upon startup, check if `$HOME/.config/klp-build/config` already exists. If it does, load the configuration. Otherwise, create a default configuration file and same with the files and directories specified in the conf.

The default paths for now are:
work directory -> `$HOME/klp-build/patches`
data directory -> `$HOME/klp-build/data`

