### PR TITLE
ksrc: Don't ignore patches without ".patch" suffix

### DIFF
--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -259,7 +259,7 @@ class GitHelper(Config):
             #   branch:file/path
             idx = 0
             for patch in patch_files.splitlines():
-                if not patch.endswith(".patch"):
+                if patch.strip().startswith("#"):
                     continue
 
                 idx += 1


### PR DESCRIPTION
Currently, when reading the "series.conf" file all lines not ending with ".patch" suffix are being ignored. Many patches, mainly old ones, have no extension in their filename, hence ignored when looking for them. This bug was making klp-build falsely report that no backported patches were found with "get-patches" and "setup" commands (e.g. CVE-2021-47369).

From now on, only commented lines will be ignored in the "series.conf"

For context, issue introduced in: a3e5beb04