### PR TITLE
templ.py: Include linux/livepatch.h header for IBT enabled kernels

### DIFF
--- a/klpbuild/templ.py
+++ b/klpbuild/templ.py
@@ -217,7 +217,7 @@ def get_exts(app, ibt_mod, ext_vars):
                             ext_list.append(f"\\t {lsym}")
                             ext_list.append(f"\\t {end}")
 
-        return '\\n'.join(ext_list)
+        return '\\n#include <linux/livepatch.h>\\n\\n' + '\\n'.join(ext_list)
 %>
 """
 


### PR DESCRIPTION
Without this header the KLP_RELOC_SYMBOL macro won't be recognized.