### PR TITLE
setup: Remove --codestreams in favor of --filter

### DIFF
--- a/klpbuild/cmd.py
+++ b/klpbuild/cmd.py
@@ -45,12 +45,6 @@ def create_parser() -> argparse.ArgumentParser:
         help="The path where source files and modules will be found",
     )
     setup.add_argument(
-        "--codestreams",
-        type=str,
-        default="",
-        help="SLE specific. Codestreams affected by the CVE. Can be used a regex, like, 15.u[34]",
-    )
-    setup.add_argument(
         "--file-funcs",
         required=False,
         action="append",
@@ -189,7 +183,6 @@ def main_func(main_args):
             args.filter,
             args.data_dir,
             args.cve,
-            args.codestreams,
             args.file_funcs,
             args.mod_file_funcs,
             args.conf_mod_file_funcs,

--- a/klpbuild/setup.py
+++ b/klpbuild/setup.py
@@ -26,7 +26,6 @@ class Setup(Config):
         lp_filter,
         data_dir,
         cve,
-        cs_arg,
         file_funcs,
         mod_file_funcs,
         conf_mod_file_funcs,
@@ -57,7 +56,6 @@ class Setup(Config):
             self.conf["cve"] = re.search(r"([0-9]+\-[0-9]+)", cve).group(1)
 
         self.no_check = no_check
-        self.codestream = cs_arg
         self.file_funcs = {}
 
         for f in file_funcs:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -13,7 +13,7 @@ def test_detect_file_without_ftrace_support(caplog):
     lp = "bsc9999999"
     cs = "15.6u0"
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
           file_funcs=[["lib/seq_buf.c", "seq_buf_putmem_hex"]],
           mod_file_funcs=[], conf_mod_file_funcs=[], mod_arg="vmlinux",
           conf="CONFIG_SMP",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,35 +17,31 @@ cs = "15.5u19"
 
 def test_missing_file_funcs():
     with pytest.raises(ValueError, match=r"You need to specify at least one of the file-funcs variants!"):
-        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-              mod_file_funcs=[], conf_mod_file_funcs=[], file_funcs=[],
-              mod_arg="vmlinux", conf=None,
+        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, mod_file_funcs=[],
+              conf_mod_file_funcs=[], file_funcs=[], mod_arg="vmlinux", conf=None,
               archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
 
 def test_missing_conf_prefix():
     with pytest.raises(ValueError, match=r"Please specify --conf with CONFIG_ prefix"):
-        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-              mod_file_funcs=[], conf_mod_file_funcs=[], file_funcs=[],
-              conf="TUN", mod_arg="vmlinux",
+        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, mod_file_funcs=[],
+              conf_mod_file_funcs=[], file_funcs=[], conf="TUN", mod_arg="vmlinux",
               archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
 
 # Check for multiple variants of file-funcs
 def test_file_funcs_ok():
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-          conf="CONFIG_TUN", mod_arg="tun",
-          mod_file_funcs=[], conf_mod_file_funcs=[],
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, conf="CONFIG_TUN",
+          mod_arg="tun", mod_file_funcs=[], conf_mod_file_funcs=[],
           file_funcs = [["drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]],
           archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-          conf="CONFIG_TUN", file_funcs=[], conf_mod_file_funcs=[],
-          mod_arg=None,
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
+          conf="CONFIG_TUN", file_funcs=[], conf_mod_file_funcs=[], mod_arg=None,
           mod_file_funcs = [["tun", "drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]],
           archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
           conf="CONFIG_TUN", mod_file_funcs=[], file_funcs=[], mod_arg=None,
           conf_mod_file_funcs = [["CONFIG_TUN", "tun", "drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]],
           archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
@@ -53,27 +49,24 @@ def test_file_funcs_ok():
 
 def test_non_existent_file():
     with pytest.raises(RuntimeError, match=r".*: File drivers/net/tuna.c not found on .*"):
-        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-              conf="CONFIG_TUN", mod_arg="tun",
-              mod_file_funcs=[], conf_mod_file_funcs=[],
+        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, conf="CONFIG_TUN",
+              mod_arg="tun", mod_file_funcs=[], conf_mod_file_funcs=[],
               file_funcs = [["drivers/net/tuna.c", "tun_chr_ioctl", "tun_free_netdev"]],
               archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
 
 def test_non_existent_module():
     with pytest.raises(RuntimeError, match=r"Module not found: tuna"):
-        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-              conf="CONFIG_TUN", mod_arg="tuna",
-              mod_file_funcs=[], conf_mod_file_funcs=[],
+        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, conf="CONFIG_TUN",
+              mod_arg="tuna", mod_file_funcs=[], conf_mod_file_funcs=[],
               file_funcs = [["drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]],
               archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
 
 def test_invalid_sym(caplog):
     with caplog.at_level(logging.WARNING):
-        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
-              conf="CONFIG_TUN", mod_arg="tun",
-              mod_file_funcs=[], conf_mod_file_funcs=[],
+        Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, conf="CONFIG_TUN",
+              mod_arg="tun", mod_file_funcs=[], conf_mod_file_funcs=[],
               file_funcs = [["drivers/net/tun.c", "tun_chr_ioctll", "tun_free_netdev"]],
               archs=utils.ARCHS, skips=None, no_check=False).setup_project_files()
 
@@ -81,7 +74,7 @@ def test_invalid_sym(caplog):
 
 
 def test_check_conf_mod_file_funcs():
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="", mod_arg="sch_qfq",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, mod_arg="sch_qfq",
           conf="CONFIG_TUN", mod_file_funcs=[], file_funcs=[],
           conf_mod_file_funcs = [["CONFIG_TUN", "tun", "drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]],
           archs=[utils.ARCH], skips=None, no_check=False).setup_project_files()
@@ -90,7 +83,7 @@ def test_check_conf_mod_file_funcs():
 def test_check_conf_mod_file_funcs():
     # Check that passing mod-file-funcs can create entries differently from general
     # --module and --file-funcs
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="", mod_arg="sch_qfq",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, mod_arg="sch_qfq",
           conf="CONFIG_NET_SCH_QFQ", conf_mod_file_funcs=[],
           file_funcs=[["net/sched/sch_qfq.c", "qfq_change_class"]],
           mod_file_funcs=[["btsdio", "drivers/bluetooth/btsdio.c", "btsdio_probe", "btsdio_remove"]],
@@ -106,7 +99,7 @@ def test_check_conf_mod_file_funcs():
     assert bts["module"] == "btsdio"
 
     # Rerun setup and now conf and module should be different
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="", mod_arg="sch_qfq",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, mod_arg="sch_qfq",
           conf="CONFIG_NET_SCH_QFQ", mod_file_funcs=[],
           file_funcs=[["net/sched/sch_qfq.c", "qfq_change_class"]],
           conf_mod_file_funcs = [ ["CONFIG_BT_HCIBTSDIO", "btsdio",

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -12,7 +12,7 @@ def test_templ_with_externalized_vars():
     lp = "bsc9999999"
     cs = "15.5u19"
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
           file_funcs=[["fs/proc/cmdline.c", "cmdline_proc_show"]],
           mod_file_funcs=[], conf_mod_file_funcs=[], mod_arg="vmlinux",
           conf="CONFIG_PROC_FS",
@@ -38,7 +38,7 @@ def test_templ_without_externalized_vars():
     lp = "bsc9999999"
     cs = "15.5u19"
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
           file_funcs=[["net/ipv6/rpl.c", "ipv6_rpl_srh_size"]],
           mod_file_funcs=[], conf_mod_file_funcs=[], mod_arg="vmlinux",
           conf="CONFIG_IPV6",
@@ -66,7 +66,7 @@ def test_check_header_file_included():
     lp = "bsc9999999"
     cs = "15.5u17"
 
-    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None, cs_arg="",
+    Setup(lp_name=lp, lp_filter=cs, data_dir=None, cve=None,
           file_funcs=[["net/ipv6/rpl.c", "ipv6_rpl_srh_size"], ["kernel/events/core.c", "perf_event_exec"]],
           mod_file_funcs=[], conf_mod_file_funcs=[], mod_arg="vmlinux",
           conf="CONFIG_IPV6",


### PR DESCRIPTION
--filter exists for a long time, so it's time to retire --codestreams.