### PR TITLE
ksrc: Don't download codestreams data with "scan"

### DIFF
--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -482,7 +482,7 @@ class GitHelper(Config):
 
             cs.set_archs(archs)
 
-            if not cs.get_boot_file("config").exists():
+            if conf and not cs.get_boot_file("config").exists():
                 data_missing.append(cs)
                 cs_missing.append(cs.name())
                 # recheck later if we can add the missing codestreams


### PR DESCRIPTION
When running the "`scan`" subcommand, don't download the codestreams data unless the "`--conf`" option is set. This small optimization makes it possible to automate "`klp-build scan`" and integrate it into other tools.