### PR TITLE
Minor improvements related to the `scan` subcommand

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -33,6 +33,21 @@ List of accepted codestreams. Must be specified in regex format.
 Example: "15\.3u[0-9]+|15\.6u0"
 .SH COMMANDS
 .TP
+.B scan
+In the scan,
+.B klp-build
+does a shallow analysis of the given CVE, searching for already patched codestreams
+and reporting those that most likley are still affected by the bug.
+This subcommand does not store any data, as it is mainly targeted for automation
+and not for livepatch development. For the latter see the
+.B setup
+subcommand.
+.RS 7
+.TP
+.BI --cve " CVE"
+The CVE to be analyzed.
+.RE
+.TP
 .B setup
 During the setup,
 .B klp-build

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -145,7 +145,7 @@ class GitHelper(Config):
 
         # Mount the command to fetch all branches for supported codestreams
         subprocess.check_output(["/usr/bin/git", "-C", str(self.kern_src), "fetch",
-                                 "--quiet", "--tags", "--force", "origin"] +
+                                 "--quiet", "--atomic", "--force", "--tags", "origin"] +
                                 list(self.kernel_branches.values()))
 
         print("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")


### PR DESCRIPTION
Add a protection against git's data corruption when multiple klp-build instances are fetching `kernel-sources`. Note that this doesn't fully shield against race-conditions.

Add definition of the `scan` subcommand.