### PR TITLE
extractor: Check if make invocation fails

### DIFF
--- a/klpbuild/codestream.py
+++ b/klpbuild/codestream.py
@@ -13,8 +13,8 @@ class Codestream:
                  "ktype", "needs_ibt", "project", "kernel", "archs", "files",
                  "modules", "repo")
 
-    def __init__(self, data_path, lp_path, sle, sp, update, rt, project="",
-                 kernel="", archs=[], files={}, modules={}):
+    def __init__(self, data_path, lp_path, sle, sp, update, rt, project,
+                 kernel, archs, files, modules):
         self.data_path = data_path
         self.lp_path = lp_path
         self.lp_name = PurePath(lp_path).name
@@ -43,14 +43,14 @@ class Codestream:
         else:
             sp = "0"
 
-        return cls(data_path, lp_path, int(sle), int(sp), int(u), rt, proj, kernel)
+        return cls(data_path, lp_path, int(sle), int(sp), int(u), rt, proj, kernel, [], {}, {})
 
 
     @classmethod
     def from_cs(cls, cs):
         match = re.search(r"(\d+)\.(\d+)(rt)?u(\d+)", cs)
         return cls("", "", int(match.group(1)), int(match.group(2)),
-                   int(match.group(4)), match.group(3))
+                   int(match.group(4)), match.group(3), "", "", [], {}, {})
 
 
     @classmethod
@@ -228,6 +228,7 @@ class Codestream:
         # Return the path is the modules was previously found
         obj = self.modules.get(mod, "")
         if obj:
+            assert self.kernel in str(obj)
             return obj
 
         # We already know the path to vmlinux, so return it

--- a/klpbuild/config.py
+++ b/klpbuild/config.py
@@ -9,6 +9,7 @@ import logging
 import os
 from collections import OrderedDict
 from pathlib import Path, PurePath
+from natsort import natsorted
 
 from klpbuild.codestream import Codestream
 
@@ -49,8 +50,10 @@ class Config:
                 self.cve = jfile["cve"]
                 self.patched_kernels = jfile["patched_kernels"]
                 self.patched_cs = jfile["patched_cs"]
-                for cs, data in jfile["codestreams"].items():
-                    self.codestreams[cs] = Codestream.from_data(data)
+                json_cs = jfile["codestreams"]
+                # Sorte the codestreams before inserting in the OrderedDict
+                for cs in natsorted(json_cs.keys()):
+                    self.codestreams[cs] = Codestream.from_data(json_cs[cs])
 
 
     def setup_user_env(self, basedir):

--- a/klpbuild/extractor.py
+++ b/klpbuild/extractor.py
@@ -408,6 +408,15 @@ class Extractor(Config):
 
         return ccp_args, env
 
+    def print_env_vars(self, fhandle, env):
+        fhandle.write("Env vars:\n")
+
+        for k, v in env.items():
+            if not k.startswith("KCP"):
+                continue
+
+            fhandle.write(f"{k}={v}\n")
+
     def process(self, args):
         i, fname, cs, fdata = args
 
@@ -447,6 +456,7 @@ class Extractor(Config):
         with open(out_log, "w") as f:
             # Write the command line used
             f.write(f"Executing ccp on {odir}\n")
+            self.print_env_vars(f, lenv)
             f.write("\n".join(args) + "\n")
             f.flush()
             try:

--- a/klpbuild/extractor.py
+++ b/klpbuild/extractor.py
@@ -181,11 +181,16 @@ class Extractor(Config):
             ofname = "." + filename.name.replace(".c", ".o.d")
             ofname = Path(filename.parent, ofname)
 
-            completed = subprocess.check_output(make_args, cwd=odir, stderr=f).decode()
-            f.write("Full output of the make command:\n")
-            f.write(str(completed).strip())
-            f.write("\n")
-            f.flush()
+            try:
+                completed = subprocess.check_output(make_args, cwd=odir,
+                                                    stderr=f).decode().strip()
+                f.write("Full output of the make command:\n")
+                f.write(str(completed))
+                f.write("\n")
+                f.flush()
+            except subprocess.CalledProcessError as exc:
+                logging.error(f"Failed to run make for {cs.name()} ({cs.kernel}). Check file {str(log_path)} for more details.")
+                raise exc
 
             # 15.4 onwards changes the regex a little: -MD -> -MMD
             # 15.6 onwards we don't have -isystem.

--- a/klpbuild/ksrc.py
+++ b/klpbuild/ksrc.py
@@ -446,7 +446,7 @@ class GitHelper(Config):
         # against the codestreams informed by the user
         all_codestreams = GitHelper.download_supported_file(self.data, self.lp_path)
 
-        if not cve:
+        if not cve or no_check:
             commits = {}
             patched_kernels = []
         else:


### PR DESCRIPTION
This can happen when the extraction process is interrupted, resulting in missing kernel files.