### PR TITLE
setup: Do not reassign archs with archs.sort()

### DIFF
--- a/klpbuild/setup.py
+++ b/klpbuild/setup.py
@@ -90,7 +90,7 @@ class Setup(Config):
         self.lp_path.mkdir(exist_ok=True)
 
         codestreams = self.setup_codestreams(cve, no_check)
-        archs = archs.sort()
+        archs.sort()
 
         logging.info("Affected architectures:")
         logging.info("\t%s", ' '.join(archs))


### PR DESCRIPTION
We don't need to assign archs back aftert sorting, since sort() returns None.