### PR TITLE
ibs: push: Get the codestream branch and rebase it on top of base branch

### DIFF
--- a/klpbuild/utils.py
+++ b/klpbuild/utils.py
@@ -253,3 +253,16 @@ def fix_mod_string(mod):
     # Modules like snd-pcm needs to be replaced by snd_pcm in LP_MODULE
     # and in kallsyms lookup
     return mod.replace("-", "_")
+
+
+def get_kgraft_branch(cs_name):
+    if '12.' in cs_name:
+        return "master-livepatch-sle12"
+
+    if '15.2' in cs_name or '15.3' in cs_name:
+        return "master-livepatch"
+
+    if "15.4" in cs_name or "15.5" in cs_name:
+        return "master-livepatch-sle15sp4"
+
+    return "master-livepatch-sle15sp6"


### PR DESCRIPTION
Until now it was required to the developer to always base the branch on top of one of branches assigned to the codestreams. As the number of base branches increase, it's easier if klp-build could make it automatically.

From now on, it's expected that the bscXXXXXX branch is based on the kgraft-patches' master branch, which doesn't include any code, since klp-build will clone that branch, and rebase it on top of a base branch related to the codestream affected.

For example, for 12.5 codestreams, it will get the branch for bscXXXXX_12.5uXXX (which should contain only the directory for the bscXXX) and rebase on top of origin/master-livepatch-sle12.

Hopefully this change will make the LP developers to check less details when creating a livepatch.