### PR TITLE
extractor: Replace '-' for "-" on module name of externalized syms

### DIFF
--- a/klpbuild/extractor.py
+++ b/klpbuild/extractor.py
@@ -249,6 +249,8 @@ class Extractor(Config):
                         continue
 
                     _, sym, var, mod = l.split(" ")
+                    # Module names should not use dashes
+                    mod = mod.replace("-", "_")
                     if not utils.is_mod(mod):
                         mod = "vmlinux"
 


### PR DESCRIPTION
Otherwise the kallsyms machinary fails to find the symbol.

@fgyanz I've tagged this to main, since it's a fix. I believe that after merged this into main we should also merge into devel.