### PR TITLE
setup: Always set archs and cve to cs_data

### DIFF
--- a/klpbuild/setup.py
+++ b/klpbuild/setup.py
@@ -72,6 +72,7 @@ class Setup(Config):
         self.cs_data.patched_kernels = patched_kernels
         # Add new codestreams to the already existing list, skipping duplicates
         self.cs_data.patched_cs = natsorted(list(set(self.cs_data.patched_cs + patched_cs)))
+        self.cs_data.cve = data["cve"]
 
         return codestreams
 
@@ -79,6 +80,7 @@ class Setup(Config):
         self.lp_path.mkdir(exist_ok=True)
 
         archs.sort()
+        self.cs_data.archs = archs
 
         logging.info("Affected architectures:")
         logging.info("\t%s", ' '.join(archs))

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -50,7 +50,7 @@ def test_templ_without_externalized_vars():
     codestreams = lp_setup.setup_codestreams(
         {"cve": None, "lp_filter": cs, "lp_skips": None, "conf": "CONFIG_IPV6", "no_check": False})
 
-    lp_setup.setup_project_files(codestreams, ffuncs, utils.ARCHS)
+    lp_setup.setup_project_files(codestreams, ffuncs, [utils.ARCH])
 
     Extractor(lp_name=lp, lp_filter=cs, apply_patches=False, avoid_ext=[]).run()
 
@@ -62,7 +62,7 @@ def test_templ_without_externalized_vars():
     for check in ["LP_MODULE", "module_notify", "linux/module.h", "klp_funcs"]:
         assert check not in content
 
-    # As the config only targets x86_64, IS_ENABLED should be set
+    # As the config only targets one arch, IS_ENABLED should be set
     assert "#if IS_ENABLED" in content
 
     # Without CVE speficied, we should have XXXX-XXXX


### PR DESCRIPTION
Also, fix the problematic test that was checking a condition that was only being triggered if only one arch was set, but was using all archs wrongly.