### PR TITLE
tox: Use the ssh-agent from host

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skip_missing_interpreters = True
 minversion = 3.28.0
 
 [testenv:{py36,py38,py310,py311,py312}-tests,tests]
+passenv = SSH_AUTH_SOCK
 description = run tests
 deps =
     pytest>=6


### PR DESCRIPTION
Fetch the ssh-keys from the ssh-agent running in the host. Needed when klp-build needs to download new codestreams from IBS during the tests.

Otherwise we get:
```
tests/test_config.py::test_filter PASSED                                                                                                                                              [  5%]
tests/test_extract.py::test_detect_file_without_ftrace_support Enter passphrase for "/home/fgonzalez/.ssh/suse-fgonzalez":
```

A better solution would be to disable downloading codestreams during the testing, but that'd require quite some changes in setup. As a temporal workaround this does the job.