### PR TITLE
Drop bsc_check from scan

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -140,17 +140,23 @@ class Codestream:
         return f"{self.sle}.{self.sp}u{self.update}"
 
 
-    def dir(self):
+    def get_ccp_dir(self):
+        """
+        Get the path to the ccp directory of the current codestream.
+
+        Returns:
+            Path: The path to the ccp directory of the current codestream.
+        """
         return Path(self.lp_path, "ccp", self.name())
 
 
     def lpdir(self):
-        return self.dir()/"lp"
+        return self.get_ccp_dir()/"lp"
 
 
     def work_dir(self, fname):
         fpath = f'work_{str(fname).replace("/", "_")}'
-        return Path(self.dir(), fpath)
+        return self.get_ccp_dir()/fpath
 
 
     def name_cs(self):

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -150,7 +150,13 @@ class Codestream:
         return Path(self.lp_path, "ccp", self.name())
 
 
-    def lpdir(self):
+    def get_lp_dir(self):
+        """
+        Get the path to the extracted livepatches directory of the current codestream.
+
+        returns:
+            path: The path to the extracted livepatches directory of the current codestream.
+        """
         return self.get_ccp_dir()/"lp"
 
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -57,6 +57,8 @@ class Codestream:
     @classmethod
     def from_cs(cls, cs):
         match = re.search(r"(\d+)\.(\d+)(rt)?u(\d+)", cs)
+        if not match:
+            raise ValueError("Filter regexp error!")
         return cls("", "", int(match.group(1)), int(match.group(2)),
                    int(match.group(4)), match.group(3), "", "", "", [], {}, {})
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -45,10 +45,11 @@ class Codestream:
             sle, _, u = cs.replace("SLE", "").replace("-RT", "").split("_")
             if "-SP" in sle:
                 sle, sp = sle.split("-SP")
-
         # MICRO-6-0_Update_2
         elif "MICRO" in cs:
             sle, sp, u = cs.replace("MICRO-", "").replace("-RT", "").replace("_Update_", "-").split("-")
+        else:
+            assert False, "codestream name should contain either SLE or MICRO!"
 
         return cls(data_path, lp_path, int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {})
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -145,7 +145,7 @@ class Codestream:
 
 
     def lpdir(self):
-        return Path(self.lp_path, "ccp", self.name(), "lp")
+        return self.dir()/"lp"
 
 
     def work_dir(self, fname):

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -160,7 +160,13 @@ class Codestream:
         return self.get_ccp_dir()/"lp"
 
 
-    def work_dir(self, fname):
+    def get_ccp_work_dir(self, fname):
+        """
+        Get the path to the klp-ccp working directory of the current codestream.
+
+        returns:
+            Path: The path to the klp-ccp working directory of the current codestream.
+        """
         fpath = f'work_{str(fname).replace("/", "_")}'
         return self.get_ccp_dir()/fpath
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -6,7 +6,7 @@
 from pathlib import Path, PurePath
 import re
 
-from klpbuild.klplib.utils import ARCH, is_mod, get_all_symbols_from_object
+from klpbuild.klplib.utils import ARCH, is_mod, get_all_symbols_from_object, get_datadir
 
 class Codestream:
     __slots__ = ("data_path", "lp_path", "lp_name", "sle", "sp", "update", "rt",
@@ -73,16 +73,11 @@ class Codestream:
                 self.update == cs.update and \
                 self.rt == cs.rt
 
-    def get_data_dir(self, arch):
-        # For the SLE usage, it should point to the place where the codestreams
-        # are downloaded
-        return Path(self.data_path, arch)
-
 
     def get_src_dir(self, arch=ARCH):
         # Only -rt codestreams have a suffix for source directory
         ktype = self.ktype.replace("-default", "")
-        return Path(self.get_data_dir(arch), "usr", "src", f"linux-{self.kernel}{ktype}")
+        return get_datadir(arch)/"usr"/"src"/f"linux-{self.kernel}{ktype}"
 
 
     def get_obj_dir(self):
@@ -99,7 +94,7 @@ class Codestream:
 
         # Strip the suffix from the filename so we can add the kernel version in the middle
         fname = f"{Path(file).stem}-{self.kname()}{Path(file).suffix}"
-        return Path(self.get_data_dir(arch), "boot", fname)
+        return get_datadir(arch)/"boot"/fname
 
     def get_repo(self):
         if self.update == 0 or self.is_micro:
@@ -191,7 +186,7 @@ class Codestream:
         else:
             mod_path = Path("lib")
 
-        return Path(self.get_data_dir(arch), mod_path, "modules", f"{self.kname()}")
+        return get_datadir(arch)/mod_path/"modules"/self.kname()
 
     # A codestream can be patching multiple objects, so get the path related to
     # the module that we are interested

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -319,7 +319,7 @@ class IBS():
                 if arch not in cs.archs:
                     continue
 
-                rpm_dir = Path(cs.dir(), arch, "rpm")
+                rpm_dir = Path(cs.get_ccp_dir(), arch, "rpm")
                 if not rpm_dir.exists():
                     logging.info(f"{cs.name()}/{arch}: rpm dir not found. Skipping.")
                     continue
@@ -371,7 +371,7 @@ class IBS():
     def delete_rpms(self, cs):
         try:
             for arch in cs.archs:
-                shutil.rmtree(Path(cs.dir(), arch, "rpm"), ignore_errors=True)
+                shutil.rmtree(Path(cs.get_ccp_dir(), arch, "rpm"), ignore_errors=True)
         except KeyError:
             pass
 
@@ -404,7 +404,7 @@ class IBS():
                         continue
 
                     # Create a directory for each arch supported
-                    dest = Path(cs.dir(), str(arch), "rpm")
+                    dest = Path(cs.get_ccp_dir(), str(arch), "rpm")
                     dest.mkdir(exist_ok=True, parents=True)
 
                     rpms.append((i, cs, prj, "standard", arch, "klp", rpm, dest))
@@ -527,11 +527,11 @@ class IBS():
             raise RuntimeError("") from e
 
         # Remove previously created directories
-        prj_path = Path(cs.dir(), "checkout")
+        prj_path = Path(cs.get_ccp_dir(), "checkout")
         if prj_path.exists():
             shutil.rmtree(prj_path)
 
-        code_path = Path(cs.dir(), "code")
+        code_path = Path(cs.get_ccp_dir(), "code")
         if code_path.exists():
             shutil.rmtree(code_path)
 

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -109,7 +109,7 @@ class IBS():
         if arch != "x86_64" and "-extra" in rpm:
             return
 
-        path_dest = cs.get_data_dir(arch)
+        path_dest = get_datadir(arch)
         path_dest.mkdir(exist_ok=True, parents=True)
 
         rpm_file = Path(dest, rpm)

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -319,7 +319,7 @@ class IBS():
                 if arch not in cs.archs:
                     continue
 
-                rpm_dir = Path(cs.get_ccp_dir(), arch, "rpm")
+                rpm_dir = Path(cs.get_ccp_dir(self.lp_name), arch, "rpm")
                 if not rpm_dir.exists():
                     logging.info(f"{cs.name()}/{arch}: rpm dir not found. Skipping.")
                     continue
@@ -371,7 +371,7 @@ class IBS():
     def delete_rpms(self, cs):
         try:
             for arch in cs.archs:
-                shutil.rmtree(Path(cs.get_ccp_dir(), arch, "rpm"), ignore_errors=True)
+                shutil.rmtree(Path(cs.get_ccp_dir(self.lp_name), arch, "rpm"), ignore_errors=True)
         except KeyError:
             pass
 
@@ -404,7 +404,7 @@ class IBS():
                         continue
 
                     # Create a directory for each arch supported
-                    dest = Path(cs.get_ccp_dir(), str(arch), "rpm")
+                    dest = Path(cs.get_ccp_dir(self.lp_name), str(arch), "rpm")
                     dest.mkdir(exist_ok=True, parents=True)
 
                     rpms.append((i, cs, prj, "standard", arch, "klp", rpm, dest))
@@ -502,7 +502,7 @@ class IBS():
 
     def create_lp_package(self, i, cs):
         kgr_path = get_user_path('kgr_patches_dir')
-        branch = get_cs_branch(cs, cs.lp_name, kgr_path)
+        branch = get_cs_branch(cs, self.lp_name, kgr_path)
         if not branch:
             logging.info(f"Could not find git branch for {cs.name()}. Skipping.")
             return
@@ -527,11 +527,11 @@ class IBS():
             raise RuntimeError("") from e
 
         # Remove previously created directories
-        prj_path = Path(cs.get_ccp_dir(), "checkout")
+        prj_path = Path(cs.get_ccp_dir(self.lp_name), "checkout")
         if prj_path.exists():
             shutil.rmtree(prj_path)
 
-        code_path = Path(cs.get_ccp_dir(), "code")
+        code_path = Path(cs.get_ccp_dir(self.lp_name), "code")
         if code_path.exists():
             shutil.rmtree(code_path)
 
@@ -569,8 +569,8 @@ class IBS():
         # Otherwise only warn the caller about this fact.
         # This scenario can occur in case of LPing function that is already
         # part of different LP in which case we modify the existing one.
-        if cs.lp_name not in os.listdir(code_path):
-            logging.warning(f"Warning: Directory {cs.lp_name} not found on branch {branch}")
+        if self.lp_name not in os.listdir(code_path):
+            logging.warning(f"Warning: Directory {self.lp_name} not found on branch {branch}")
 
         # Fix RELEASE version
         with open(Path(code_path, "scripts", "release-version.sh"), "w") as f:

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -423,7 +423,7 @@ class GitHelper():
         return len(commits[cs.name_cs()]["commits"]) > 0
 
 
-    def scan(self, lp_name, cve, conf, no_check):
+    def scan(self, cve, conf, no_check, savedir=None):
         # Always get the latest supported.csv file and check the content
         # against the codestreams informed by the user
         all_codestreams = get_supported_codestreams()
@@ -432,7 +432,7 @@ class GitHelper():
             commits = {}
             patched_kernels = []
         else:
-            commits = self.get_commits(cve, utils.get_workdir(lp_name))
+            commits = self.get_commits(cve, savedir)
             patched_kernels = self.get_patched_kernels(all_codestreams, commits, cve)
 
         # list of codestreams that matches the file-funcs argument
@@ -475,7 +475,7 @@ class GitHelper():
         if data_missing:
             logging.info("Download the necessary data from the following codestreams:")
             logging.info("\t%s\n", " ".join(cs_missing))
-            IBS(lp_name, self.lp_filter).download_cs_data(data_missing)
+            IBS("", self.lp_filter).download_cs_data(data_missing)
             logging.info("Done.")
 
             for cs in data_missing:

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -417,7 +417,7 @@ class GitHelper():
 
 
     @staticmethod
-    def download_supported_file(data_path, lp_path):
+    def download_supported_file():
         logging.info("Downloading codestreams file")
         cs_url = "https://gitlab.suse.de/live-patching/sle-live-patching-data/raw/master/supported.csv"
         suse_cert = Path("/etc/ssl/certs/SUSE_Trust_Root.pem")
@@ -454,8 +454,8 @@ class GitHelper():
             else:
                 patchid = ""
 
-            codestreams.append(Codestream.from_codestream(data_path, lp_path, full_cs,
-                                                          proj, patchid, kernel))
+            codestreams.append(Codestream.from_codestream(full_cs, proj,
+                                                          patchid, kernel))
 
         return codestreams
 
@@ -463,7 +463,7 @@ class GitHelper():
     def scan(self, cve, conf, no_check):
         # Always get the latest supported.csv file and check the content
         # against the codestreams informed by the user
-        all_codestreams = GitHelper.download_supported_file(utils.get_datadir(), utils.get_workdir(self.lp_name))
+        all_codestreams = GitHelper.download_supported_file()
 
         if not cve or no_check:
             commits = {}

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -159,8 +159,8 @@ class GitHelper():
         # List of upstream commits, in creation date order
         ucommits = []
 
-        upatches = utils.get_workdir(lp_name)/"upstream"
-        upatches.mkdir(exist_ok=True, parents=True)
+        upstream_patches_dir = utils.get_workdir(lp_name)/"upstream"
+        upstream_patches_dir.mkdir(exist_ok=True, parents=True)
 
         # Get backported commits from all possible branches, in order to get
         # different versions of the same backport done in the CVE branches.
@@ -284,7 +284,7 @@ class GitHelper():
         # created/merged.
         ucommits_sort = []
         for c in ucommits:
-            d, msg = GitHelper.get_commit_data(c, upatches)
+            d, msg = GitHelper.get_commit_data(c, upstream_patches_dir)
             ucommits_sort.append((d, c, msg))
 
         ucommits_sort.sort()

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -18,7 +18,7 @@ from natsort import natsorted
 from klpbuild.klplib import utils
 from klpbuild.klplib.config import get_user_path
 from klpbuild.klplib.ibs import IBS
-from klpbuild.klplib.supported import download_supported_file
+from klpbuild.klplib.supported import get_supported_codestreams
 
 
 class GitHelper():
@@ -419,7 +419,7 @@ class GitHelper():
     def scan(self, cve, conf, no_check):
         # Always get the latest supported.csv file and check the content
         # against the codestreams informed by the user
-        all_codestreams = download_supported_file()
+        all_codestreams = get_supported_codestreams()
 
         if not cve or no_check:
             commits = {}

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -126,6 +126,15 @@ class GitHelper():
         return d, msg
 
 
+    def fetch_kernel_branches(self):
+        logging.info("Fetching changes from all supported branches...")
+
+        # Mount the command to fetch all branches for supported codestreams
+        subprocess.check_output(["/usr/bin/git", "-C", str(self.kern_src), "fetch",
+                                 "--quiet", "--atomic", "--force", "--tags", "origin"] +
+                                list(self.kernel_branches.values()))
+
+
     def get_commits(self, lp_name, cve):
         if not self.kern_src:
             logging.info("kernel_src_dir not found, skip getting SUSE commits")
@@ -141,12 +150,7 @@ class GitHelper():
             logging.info("Invalid CVE number '%s', skipping the processing of getting the patches.", cve)
             return {}
 
-        print("Fetching changes from all supported branches...")
-
-        # Mount the command to fetch all branches for supported codestreams
-        subprocess.check_output(["/usr/bin/git", "-C", str(self.kern_src), "fetch",
-                                 "--quiet", "--atomic", "--force", "--tags", "origin"] +
-                                list(self.kernel_branches.values()))
+        self.fetch_kernel_branches()
 
         print("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 

--- a/klpbuild/klplib/supported.py
+++ b/klpbuild/klplib/supported.py
@@ -14,6 +14,12 @@ SUPPORTED_CS_URL = "https://gitlab.suse.de/live-patching/sle-live-patching-data/
 SUSE_CERT = Path("/etc/ssl/certs/SUSE_Trust_Root.pem")
 
 def get_supported_codestreams():
+    """
+    Download and parse the list of supported codestreams.
+
+    Returns:
+        list[Codestream]: A list of supported codestreams.
+    """
     supported_codestreams = []
 
     for line in __download_supported_file():
@@ -37,6 +43,13 @@ def get_supported_codestreams():
 
 
 def __download_supported_file():
+    """
+    Download and return the lines of the supported file.
+
+    Returns:
+        list[str]: The list of lines of the supported file, excluding the
+        header.
+    """
     logging.info("Downloading codestreams file")
 
     if SUSE_CERT.exists():

--- a/klpbuild/klplib/supported.py
+++ b/klpbuild/klplib/supported.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2021-2025 SUSE
+# Author: Marcos Paulo de Souza <mpdesouza@suse.com
+
+import logging
+import re
+import requests
+from pathlib import Path
+
+from klpbuild.klplib.codestream import Codestream
+
+SUPPORTED_CS_URL = "https://gitlab.suse.de/live-patching/sle-live-patching-data/raw/master/supported.csv"
+SUSE_CERT = Path("/etc/ssl/certs/SUSE_Trust_Root.pem")
+
+def download_supported_file():
+    logging.info("Downloading codestreams file")
+
+    if SUSE_CERT.exists():
+        req = requests.get(SUPPORTED_CS_URL, verify=SUSE_CERT, timeout=15)
+    else:
+        req = requests.get(SUPPORTED_CS_URL, timeout=15)
+
+    # exit on error
+    req.raise_for_status()
+
+    first_line = True
+    codestreams = []
+    for line in req.iter_lines():
+        # skip empty lines
+        if not line:
+            continue
+
+        # skip file header
+        if first_line:
+            first_line = False
+            continue
+
+        # remove the last two columns, which are dates of the line
+        # and add a fifth field with the forth one + rpm- prefix, and
+        # remove the build counter number
+        full_cs, proj, kernel_full, _, _ = line.decode("utf-8").strip().split(",")
+
+        kernel = re.sub(r"\.\d+$", "", kernel_full)
+
+        # MICRO releases contain project/patchid format
+        if "/" in proj:
+            proj, patchid = proj.split("/")
+        else:
+            patchid = ""
+
+        codestreams.append(Codestream.from_codestream(full_cs, proj, patchid,
+                                                      kernel))
+
+    return codestreams

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -431,7 +431,7 @@ class TemplateGen():
         # Only add the inc_dir if CE is used, since it's the only backend that
         # produces the proto.h headers
         if len(proto_files) > 0:
-            lp_inc_dir = cs.dir()
+            lp_inc_dir = cs.get_ccp_dir()
 
         # Only populate the config check in the header if the livepatch is
         # patching code under only one config. Otherwise let the developer to

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -453,7 +453,7 @@ class TemplateGen():
 
     def __generate_lp_file(self, lp_path, cs, src_file, use_src_name=False):
         if src_file:
-            lp_inc_dir = str(cs.work_dir(src_file))
+            lp_inc_dir = str(cs.get_ccp_work_dir(src_file))
             lp_file = cs.lp_out_file(src_file)
             fdata = cs.files[str(src_file)]
         else:

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -410,7 +410,7 @@ class TemplateGen():
 
     def __generate_patched_conf(self, cs):
         render_vars = {"cs_files": cs.files, "check_enabled": self.check_enabled}
-        with open(Path(cs.lpdir(), "patched_funcs.csv"), "w") as f:
+        with open(Path(cs.get_lp_dir(), "patched_funcs.csv"), "w") as f:
             f.write(Template(TEMPL_PATCHED).render(**render_vars))
 
     def __generate_header_file(self, lp_path, cs):
@@ -515,7 +515,7 @@ class TemplateGen():
             f.write(Template(TEMPL_SUSE_HEADER + temp_str, lookup=lpdir).render(**tvars))
 
     def generate_livepatches(self, cs):
-        lp_path = cs.lpdir()
+        lp_path = cs.get_lp_dir()
         lp_path.mkdir(exist_ok=True)
 
         files = cs.files
@@ -541,8 +541,8 @@ class TemplateGen():
 
     # Create Kbuild.inc file adding an entry for all generated livepatch files.
     def __create_kbuild(self, cs):
-        render_vars = {"bsc": cs.lp_name, "cs": cs, "lpdir": cs.lpdir()}
-        with open(Path(cs.lpdir(), "Kbuild.inc"), "w") as f:
+        render_vars = {"bsc": cs.lp_name, "cs": cs, "lpdir": cs.get_lp_dir()}
+        with open(Path(cs.get_lp_dir(), "Kbuild.inc"), "w") as f:
             f.write(Template(TEMPL_KBUILD).render(**render_vars))
 
     def generate_commit_msg_file(self):

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -410,11 +410,11 @@ class TemplateGen():
 
     def __generate_patched_conf(self, cs):
         render_vars = {"cs_files": cs.files, "check_enabled": self.check_enabled}
-        with open(Path(cs.get_lp_dir(), "patched_funcs.csv"), "w") as f:
+        with open(Path(cs.get_lp_dir(self.lp_name), "patched_funcs.csv"), "w") as f:
             f.write(Template(TEMPL_PATCHED).render(**render_vars))
 
     def __generate_header_file(self, lp_path, cs):
-        out_name = f"livepatch_{cs.lp_name}.h"
+        out_name = f"livepatch_{self.lp_name}.h"
 
         lp_inc_dir = Path()
         proto_files = []
@@ -431,7 +431,7 @@ class TemplateGen():
         # Only add the inc_dir if CE is used, since it's the only backend that
         # produces the proto.h headers
         if len(proto_files) > 0:
-            lp_inc_dir = cs.get_ccp_dir()
+            lp_inc_dir = cs.get_ccp_dir(self.lp_name)
 
         # Only populate the config check in the header if the livepatch is
         # patching code under only one config. Otherwise let the developer to
@@ -453,8 +453,8 @@ class TemplateGen():
 
     def __generate_lp_file(self, lp_path, cs, src_file, use_src_name=False):
         if src_file:
-            lp_inc_dir = str(cs.get_ccp_work_dir(src_file))
-            lp_file = cs.lp_out_file(src_file)
+            lp_inc_dir = str(cs.get_ccp_work_dir(self.lp_name, src_file))
+            lp_file = cs.lp_out_file(self.lp_name, src_file)
             fdata = cs.files[str(src_file)]
         else:
             lp_inc_dir = Path("non-existent")
@@ -468,7 +468,7 @@ class TemplateGen():
         if use_src_name:
             out_name = lp_file
         else:
-            out_name = f"livepatch_{cs.lp_name}.c"
+            out_name = f"livepatch_{self.lp_name}.c"
 
         user, email = get_mail()
         cve = get_codestreams_data('cve')
@@ -478,8 +478,8 @@ class TemplateGen():
         tvars = {
             "include_header": "livepatch_" in out_name,
             "cve": cve,
-            "lp_name": cs.lp_name,
-            "lp_num": cs.lp_name.replace("bsc", ""),
+            "lp_name": self.lp_name,
+            "lp_num": self.lp_name.replace("bsc", ""),
             "fname": str(Path(out_name).with_suffix("")).replace("-", "_"),
             "year": datetime.today().year,
             "user": user,
@@ -515,7 +515,7 @@ class TemplateGen():
             f.write(Template(TEMPL_SUSE_HEADER + temp_str, lookup=lpdir).render(**tvars))
 
     def generate_livepatches(self, cs):
-        lp_path = cs.get_lp_dir()
+        lp_path = cs.get_lp_dir(self.lp_name)
         lp_path.mkdir(exist_ok=True)
 
         files = cs.files
@@ -541,8 +541,8 @@ class TemplateGen():
 
     # Create Kbuild.inc file adding an entry for all generated livepatch files.
     def __create_kbuild(self, cs):
-        render_vars = {"bsc": cs.lp_name, "cs": cs, "lpdir": cs.get_lp_dir()}
-        with open(Path(cs.get_lp_dir(), "Kbuild.inc"), "w") as f:
+        render_vars = {"bsc": self.lp_name, "cs": cs, "lpdir": cs.get_lp_dir(self.lp_name)}
+        with open(Path(cs.get_lp_dir(self.lp_name), "Kbuild.inc"), "w") as f:
             f.write(Template(TEMPL_KBUILD).render(**render_vars))
 
     def generate_commit_msg_file(self):

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -288,14 +288,17 @@ def get_workdir(lp_name):
     return get_user_path('work_dir')/lp_name
 
 
-def get_datadir():
+def get_datadir(arch=""):
     """
     Get the data directory.
 
     Returns:
         Path: The full path to the livepatch file.
     """
-    return get_user_path('data_dir')
+    if arch:
+        assert arch in ARCHS
+    data_dir = get_user_path('data_dir')
+    return data_dir/arch if arch else data_dir
 
 
 def get_tests_path(lp_name):

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -21,12 +21,8 @@ def main():
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    # NOTE: Here I'm assuming the codestream is only loaded for plugins that
-    # get the livepatch name, not sure yet it's ok to assume it
     if hasattr(args, 'name'):
         load_codestreams(args.name)
-    else:
-        load_codestreams('bsc_check')
 
     if args.cmd == "setup":
         setup = Setup(args.name)
@@ -50,7 +46,7 @@ def main():
         GitHelper(args.filter).get_commits(args.cve, get_workdir(args.name))
 
     elif args.cmd == "scan":
-        GitHelper("").scan("bsc_check", args.cve, args.conf, False)
+        GitHelper("").scan(args.cve, args.conf, False)
 
     elif args.cmd == "format-patches":
         GitHelper(args.filter).format_patches(args.name, args.version)

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -46,13 +46,13 @@ def main():
         Inliner(args.name, args.codestream).check_inline(args.file, args.symbol)
 
     elif args.cmd == "get-patches":
-        GitHelper(args.name, args.filter).get_commits(args.cve)
+        GitHelper(args.filter).get_commits(args.name, args.cve)
 
     elif args.cmd == "scan":
-        GitHelper("bsc_check", "").scan(args.cve, args.conf, False)
+        GitHelper("").scan("bsc_check", args.cve, args.conf, False)
 
     elif args.cmd == "format-patches":
-        GitHelper(args.name, args.filter).format_patches(args.version)
+        GitHelper(args.filter).format_patches(args.name, args.version)
 
     elif args.cmd == "status":
         IBS(args.name, args.filter).status(args.wait)

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -10,6 +10,7 @@ from klpbuild.klplib.cmd import create_parser
 from klpbuild.klplib.codestreams_data import load_codestreams
 from klpbuild.klplib.ibs import IBS
 from klpbuild.klplib.ksrc import GitHelper
+from klpbuild.klplib.utils import get_workdir
 from klpbuild.plugins.extractor import Extractor
 from klpbuild.plugins.inline import Inliner
 from klpbuild.plugins.setup import Setup
@@ -46,7 +47,7 @@ def main():
         Inliner(args.name, args.codestream).check_inline(args.file, args.symbol)
 
     elif args.cmd == "get-patches":
-        GitHelper(args.filter).get_commits(args.name, args.cve)
+        GitHelper(args.filter).get_commits(args.cve, get_workdir(args.name))
 
     elif args.cmd == "scan":
         GitHelper("").scan("bsc_check", args.cve, args.conf, False)

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -495,7 +495,7 @@ class Extractor():
         i = 1
         for cs in working_cs:
             # remove any previously generated files and leftover patches
-            shutil.rmtree(cs.dir(), ignore_errors=True)
+            shutil.rmtree(cs.get_ccp_dir(), ignore_errors=True)
             self.remove_patches(cs, self.quilt_log)
 
             # Apply patches before the LPs were created

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -430,7 +430,7 @@ class Extractor():
 
         logging.info(f"{idx} {cs_info} {fname}")
 
-        out_dir = cs.work_dir(fname)
+        out_dir = cs.get_ccp_work_dir(fname)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         # create symlink to the respective codestream file
@@ -572,7 +572,7 @@ class Extractor():
             logging.warning(json.dumps(missing_syms, indent=4))
 
     def get_work_lp_file(self, cs, fname):
-        return Path(cs.work_dir(fname), cs.lp_out_file(fname))
+        return Path(cs.get_ccp_work_dir(fname), cs.lp_out_file(fname))
 
     def get_cs_code(self, args):
         cs_files = {}

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -361,7 +361,7 @@ class Extractor():
         return None
 
     def cmd_args(self, cs, fname, out_dir, fdata, cmd):
-        lp_out = Path(out_dir, cs.lp_out_file(fname))
+        lp_out = Path(out_dir, cs.lp_out_file(self.lp_name, fname))
 
         funcs = ",".join(fdata["symbols"])
 
@@ -430,7 +430,7 @@ class Extractor():
 
         logging.info(f"{idx} {cs_info} {fname}")
 
-        out_dir = cs.get_ccp_work_dir(fname)
+        out_dir = cs.get_ccp_work_dir(self.lp_name, fname)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         # create symlink to the respective codestream file
@@ -468,7 +468,7 @@ class Extractor():
 
         cs.files[fname]["ext_symbols"] = self.get_symbol_list(out_dir)
 
-        lp_out = Path(out_dir, cs.lp_out_file(fname))
+        lp_out = Path(out_dir, cs.lp_out_file(self.lp_name, fname))
 
         # Remove the local path prefix of the klp-ccp generated comments
         # Open the file, read, seek to the beginning, write the new data, and
@@ -495,7 +495,7 @@ class Extractor():
         i = 1
         for cs in working_cs:
             # remove any previously generated files and leftover patches
-            shutil.rmtree(cs.get_ccp_dir(), ignore_errors=True)
+            shutil.rmtree(cs.get_ccp_dir(self.lp_name), ignore_errors=True)
             self.remove_patches(cs, self.quilt_log)
 
             # Apply patches before the LPs were created
@@ -572,7 +572,7 @@ class Extractor():
             logging.warning(json.dumps(missing_syms, indent=4))
 
     def get_work_lp_file(self, cs, fname):
-        return Path(cs.get_ccp_work_dir(fname), cs.lp_out_file(fname))
+        return Path(cs.get_ccp_work_dir(self.lp_name, fname), cs.lp_out_file(self.lp_name, fname))
 
     def get_cs_code(self, args):
         cs_files = {}

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -594,7 +594,7 @@ class Extractor():
                 # We have problems with externalized symbols on macros. Ignore
                 # codestream names specified on paths that are placed on the
                 # expanded macros
-                src = re.sub(f"{cs.get_data_dir(utils.ARCH)}.+{file}", "", src)
+                src = re.sub(f"{utils.get_datadir(utils.ARCH)}.+{file}", "", src)
                 # We can have more details that can differ for long expanded
                 # macros, like the patterns bellow
                 src = re.sub(r"\.lineno = \d+,", "", src)

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -64,10 +64,11 @@ class Setup():
 
         # Called at this point because codestreams is populated
         # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-        commits, patched_cs, patched_kernels, codestreams = ksrc.scan(self.lp_name,
-                                                                      data["cve"],
+        commits, patched_cs, patched_kernels, codestreams = ksrc.scan(data["cve"],
                                                                       data["conf"],
-                                                                      data["no_check"])
+                                                                      data["no_check"],
+                                                                      utils.get_workdir(self.lp_name))
+
         # Add new codestreams to the already existing list, skipping duplicates
         old_patched_cs = get_codestreams_data('patched_cs')
         new_patched_cs = natsorted(list(set(old_patched_cs + patched_cs)))

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -60,11 +60,12 @@ class Setup():
         if not self.lp_name.startswith("bsc"):
             raise ValueError("Please use prefix 'bsc' when creating a livepatch for codestreams")
 
-        ksrc = GitHelper(self.lp_name, data["lp_filter"])
+        ksrc = GitHelper(data["lp_filter"])
 
         # Called at this point because codestreams is populated
         # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-        commits, patched_cs, patched_kernels, codestreams = ksrc.scan(data["cve"],
+        commits, patched_cs, patched_kernels, codestreams = ksrc.scan(self.lp_name,
+                                                                      data["cve"],
                                                                       data["conf"],
                                                                       data["no_check"])
         # Add new codestreams to the already existing list, skipping duplicates

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Vincenzo Mezzela
+
+import pytest
+
+from klpbuild.klplib.codestream import Codestream
+
+def test_wrong_cs_filter():
+    with pytest.raises(ValueError, match=r"Filter regexp error!"):
+        Codestream.from_cs("wrong-filter")

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -14,5 +14,5 @@ def test_multiline_upstream_commit_subject():
 # This CVE is already covered on all codestreams
 def test_scan_all_cs_patched(caplog):
     with pytest.raises(SystemExit):
-        GitHelper("bsc_check", "").scan("2022-48801", "", False)
+        GitHelper("").scan("bsc_check", "2022-48801", "", False)
     assert "All supported codestreams are already patched" not in caplog.text

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -14,5 +14,5 @@ def test_multiline_upstream_commit_subject():
 # This CVE is already covered on all codestreams
 def test_scan_all_cs_patched(caplog):
     with pytest.raises(SystemExit):
-        GitHelper("").scan("bsc_check", "2022-48801", "", False)
+        GitHelper("").scan("2022-48801", "", False)
     assert "All supported codestreams are already patched" not in caplog.text


### PR DESCRIPTION
Before this patch, executing the `scan` command would create a livepatch working directory, even though it should not setup any workspace (which is instead done by the `setup` command).

There are two reasons behind this misbheavior:

1.  `scan` is a method of the `GitHelper` class, which includes `lp_name` as one of its fields. While this fiels is irrelevant for scan, it was still required, forcing us to provide a dummy value just to instantiate the GitHelper object. See `main.py`:
    ```py
    elif args.cmd == "scan":
            GitHelper("bsc_check", "", "").scan(args.cve, args.conf, False)
    ```
    Here, `bsc_check` was used as a placeholder `lp_name` just to allow instantiation.

2. `scan` relied on `get_commits` (the function behind the `get-patches` command), which did more than just retrieving fixes and upstream commits. It also stored them in the livepatch workdir, effectively creating an implicit `bsc_check` directory.

Furthermore, `scan` uses the function `download_supported_file`, which requires the `lp_name` (for the `lp_path`) even though its job is just to retrieve the supported codestreams, a thing that doesn't require and it's not related at all to the `lp_name` and the `lp_path` of a specific livepatch.

The reason why this is required is that the function `download_supported_file`, beside downloading the supported file, also parses it and return the supported codestreams in the form of a list of `Codestream` objects, which among their fields also have the `lp_path`, `lp_name` and `data_path`.

These three fields are not strictly required in the `Codestream` class, because they can be retrieved at runtime from the config file and from the current livepatch name.

So to ensure the `scan` command does not create any working directory, I've first dropped `data_path`, `lp_path` and `lp_name` fields from the `Codestream` class and from the `download_supported_file` function (which has also been moved in a dedicated module in klplib since this is not strictly related to `ksrc` which should only concern kernel sources).

Coming back to the issue `1`, I've dropped `lp_name` field from the `GitHelper` so it is no longer required when instantiating the class. To solve issue `2` I made `get_commits` capable of storing patches only when explicitly requested.

Now, scan can do its job without requiring a working directory.

While working on it, I renamed some variables and functions here and there to help me reading the code.

I believe there are other places where we should drop unnecessary fields: for instance, when dropping "bsc_check", I had to write something like:
```py
IBS("", self.lp_filter).download_cs_data(data_missing)
```
Here with `IBS` it's happening the same problem as with `GitHelper`, but that's surely an issue for another Pull Request.