### PR TITLE
Introduce plugin system

### DIFF
--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -4,28 +4,37 @@
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
 import argparse
-import sys
 
 from klpbuild.klplib.utils import ARCHS
 
-
-def create_parser() -> argparse.ArgumentParser:
-    parentparser = argparse.ArgumentParser(add_help=False)
+def add_arg_lp_name(parentparser, mandatory=True):
     parentparser.add_argument(
         "-n",
         "--name",
         type=str,
-        required=True,
+        required=mandatory,
         help="The livepatch name. This will be the directory name of the "
         "resulting livepatches.",
     )
-    parentparser.add_argument("--filter", type=str, required='log' in sys.argv, dest="lp_filter",
-                              help=r"Filter out codestreams using a regex. Example: 15\.3u[0-9]+")
 
-    parser = argparse.ArgumentParser(add_help=False)
-    sub = parser.add_subparsers(dest="cmd")
 
-    setup = sub.add_parser("setup", parents=[parentparser])
+def add_arg_lp_filter(parentparser, mandatory=False):
+    parentparser.add_argument(
+        "--filter",
+        type=str,
+        required=mandatory,
+        dest="lp_filter",
+        help=r"Filter out codestreams using a regex. Example: 15\.3u[0-9]+"
+    )
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parentparser = argparse.ArgumentParser(add_help=False)
+    sub = parentparser.add_subparsers(dest="cmd")
+
+    setup = sub.add_parser("setup")
+    add_arg_lp_name(setup)
+    add_arg_lp_filter(setup)
     setup.add_argument("--cve", type=str, help="SLE specific. The CVE assigned to this livepatch")
     setup.add_argument("--conf", type=str, required=True, help="The kernel CONFIG used to be build the livepatch")
     setup.add_argument(
@@ -74,7 +83,9 @@ def create_parser() -> argparse.ArgumentParser:
         help="SLE specific. Supported architectures for this livepatch",
     )
 
-    check_inline = sub.add_parser("check-inline", parents=[parentparser])
+    check_inline = sub.add_parser("check-inline")
+    add_arg_lp_name(check_inline)
+    add_arg_lp_filter(check_inline)
     check_inline.add_argument(
         "--codestream",
         type=str,
@@ -95,7 +106,9 @@ def create_parser() -> argparse.ArgumentParser:
         help="Symbol to be found",
     )
 
-    extract_opts = sub.add_parser("extract", parents=[parentparser])
+    extract_opts = sub.add_parser("extract")
+    add_arg_lp_name(extract_opts)
+    add_arg_lp_filter(extract_opts)
     extract_opts.add_argument(
         "--avoid-ext",
         nargs="+",
@@ -108,14 +121,21 @@ def create_parser() -> argparse.ArgumentParser:
     extract_opts.add_argument(
         "--apply-patches", action="store_true", help="Apply patches found by get-patches subcommand, if they exist"
     )
-    diff_opts = sub.add_parser("cs-diff", parents=[parentparser])
+
+    diff_opts = sub.add_parser("cs-diff")
+    add_arg_lp_name(diff_opts)
+    add_arg_lp_filter(diff_opts)
 
     fmt = sub.add_parser(
-        "format-patches", parents=[parentparser], help="SLE specific. Extract patches from kgraft-patches"
+        "format-patches", help="SLE specific. Extract patches from kgraft-patches"
     )
+    add_arg_lp_name(fmt)
+    add_arg_lp_filter(fmt)
     fmt.add_argument("-v", "--version", type=int, required=True, help="Version to be added, like vX")
 
-    patches = sub.add_parser("get-patches", parents=[parentparser])
+    patches = sub.add_parser("get-patches")
+    add_arg_lp_name(patches)
+    add_arg_lp_filter(patches)
     patches.add_argument(
         "--cve", required=True, help="SLE specific. CVE number to search for related backported patches"
     )
@@ -128,23 +148,32 @@ def create_parser() -> argparse.ArgumentParser:
         "--conf", required=False, help="SLE specific. Helps to check only the codestreams that have this config set."
     )
 
-    sub.add_parser("cleanup", parents=[parentparser], help="SLE specific. Remove livepatch packages from IBS")
+    cleanup =sub.add_parser("cleanup", help="SLE specific. Remove livepatch packages from IBS")
+    add_arg_lp_name(cleanup)
+    add_arg_lp_filter(cleanup)
 
-    sub.add_parser(
+    test = sub.add_parser(
         "prepare-tests",
-        parents=[parentparser],
         help="SLE specific. Download the built tests and check for LP dependencies",
     )
+    add_arg_lp_name(test)
+    add_arg_lp_filter(test)
 
     push = sub.add_parser(
-        "push", parents=[parentparser], help="SLE specific. Push livepatch packages to IBS to be built"
+        "push", help="SLE specific. Push livepatch packages to IBS to be built"
     )
+    add_arg_lp_name(push)
+    add_arg_lp_filter(push)
     push.add_argument("--wait", action="store_true", help="Wait until all codestreams builds are finished")
 
-    status = sub.add_parser("status", parents=[parentparser], help="SLE specific. Check livepatch build status on IBS")
+    status = sub.add_parser("status", help="SLE specific. Check livepatch build status on IBS")
+    add_arg_lp_name(status)
+    add_arg_lp_filter(status)
     status.add_argument("--wait", action="store_true", help="Wait until all codestreams builds are finished")
 
-    log = sub.add_parser("log", parents=[parentparser], help="SLE specific. Get build log from IBS")
+    log = sub.add_parser("log", help="SLE specific. Get build log from IBS")
+    add_arg_lp_name(log)
+    add_arg_lp_filter(log, mandatory=True)
     log.add_argument("--arch", type=str, default="x86_64", choices=ARCHS, help="Build architecture")
 
-    return parser
+    return parentparser

--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -6,6 +6,7 @@
 import argparse
 
 from klpbuild.klplib.utils import ARCHS
+from klpbuild.klplib.plugins import register_plugins_argparser
 
 def add_arg_lp_name(parentparser, mandatory=True):
     parentparser.add_argument(
@@ -32,6 +33,10 @@ def create_parser() -> argparse.ArgumentParser:
     parentparser = argparse.ArgumentParser(add_help=False)
     sub = parentparser.add_subparsers(dest="cmd")
 
+    register_plugins_argparser(sub)
+
+    # NOTE: all the code below should be gone when all the module will be
+    # converted into plugins
     setup = sub.add_parser("setup")
     add_arg_lp_name(setup)
     add_arg_lp_filter(setup)
@@ -140,13 +145,6 @@ def create_parser() -> argparse.ArgumentParser:
         "--cve", required=True, help="SLE specific. CVE number to search for related backported patches"
     )
 
-    scan = sub.add_parser("scan")
-    scan.add_argument(
-        "--cve", required=True, help="SLE specific. Shows which codestreams are vulnerable to the CVE"
-    )
-    scan.add_argument(
-        "--conf", required=False, help="SLE specific. Helps to check only the codestreams that have this config set."
-    )
 
     cleanup =sub.add_parser("cleanup", help="SLE specific. Remove livepatch packages from IBS")
     add_arg_lp_name(cleanup)

--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -19,7 +19,7 @@ def create_parser() -> argparse.ArgumentParser:
         help="The livepatch name. This will be the directory name of the "
         "resulting livepatches.",
     )
-    parentparser.add_argument("--filter", type=str, required='log' in sys.argv,
+    parentparser.add_argument("--filter", type=str, required='log' in sys.argv, dest="lp_filter",
                               help=r"Filter out codestreams using a regex. Example: 15\.3u[0-9]+")
 
     parser = argparse.ArgumentParser(add_help=False)

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -269,7 +269,7 @@ class GitHelper():
 
                     # Skip commits that change one single line. Most likely just a
                     # reference update.
-                    if stats.split()[0] is "1":
+                    if stats.split()[0] == "1":
                         continue
 
                     # Sometimes we can have a commit that touches two files. In

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -17,8 +17,6 @@ from natsort import natsorted
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.config import get_user_path
-from klpbuild.klplib.ibs import IBS
-from klpbuild.klplib.supported import get_supported_codestreams
 
 
 class GitHelper():
@@ -422,95 +420,3 @@ class GitHelper():
 
         return len(commits[cs.name_cs()]["commits"]) > 0
 
-
-    def scan(self, cve, conf, no_check, savedir=None):
-        # Always get the latest supported.csv file and check the content
-        # against the codestreams informed by the user
-        all_codestreams = get_supported_codestreams()
-
-        if not cve or no_check:
-            commits = {}
-            patched_kernels = []
-        else:
-            commits = self.get_commits(cve, savedir)
-            patched_kernels = self.get_patched_kernels(all_codestreams, commits, cve)
-
-        # list of codestreams that matches the file-funcs argument
-        working_cs = []
-        patched_cs = []
-        unaffected_cs = []
-        data_missing = []
-        cs_missing = []
-        conf_not_set = []
-
-        if no_check:
-            logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
-
-        for cs in all_codestreams:
-            # Skip patched codestreams
-            if not no_check:
-                if cs.kernel in patched_kernels:
-                    patched_cs.append(cs.name())
-                    continue
-
-                if not GitHelper.cs_is_affected(cs, cve, commits):
-                    unaffected_cs.append(cs)
-                    continue
-
-            cs.set_archs()
-
-            if conf and not cs.get_boot_file("config").exists():
-                data_missing.append(cs)
-                cs_missing.append(cs.name())
-                # recheck later if we can add the missing codestreams
-                continue
-
-            if conf and not cs.get_all_configs(conf):
-                conf_not_set.append(cs)
-                continue
-
-            working_cs.append(cs)
-
-        # Found missing cs data, downloading and extract
-        if data_missing:
-            logging.info("Download the necessary data from the following codestreams:")
-            logging.info("\t%s\n", " ".join(cs_missing))
-            IBS("", self.lp_filter).download_cs_data(data_missing)
-            logging.info("Done.")
-
-            for cs in data_missing:
-                # Ok, the downloaded codestream has the configuration set
-                if cs.get_all_configs(conf):
-                    working_cs.append(cs)
-                # Nope, the config is missing, so don't add it to working_cs
-                else:
-                    conf_not_set.append(cs)
-
-        if conf_not_set:
-            cs_list = utils.classify_codestreams(conf_not_set)
-            logging.info("Skipping codestreams without %s set:", conf)
-            logging.info("\t%s", " ".join(cs_list))
-
-        if patched_cs:
-            cs_list = utils.classify_codestreams(patched_cs)
-            logging.info("Skipping already patched codestreams:")
-            logging.info("\t%s", " ".join(cs_list))
-
-        if unaffected_cs:
-            cs_list = utils.classify_codestreams(unaffected_cs)
-            logging.info("Skipping unaffected codestreams (missing backports):")
-            logging.info("\t%s", " " .join(cs_list))
-
-        # working_cs will contain the final dict of codestreams that wast set
-        # by the user, avoid downloading missing codestreams that are not affected
-        working_cs = utils.filter_codestreams(self.lp_filter, working_cs, verbose=True)
-
-        if not working_cs:
-            logging.info("All supported codestreams are already patched. Exiting klp-build")
-            sys.exit(0)
-
-        logging.info("All affected codestreams:")
-        cs_list = utils.classify_codestreams(working_cs)
-        logging.info("\t%s", " ".join(cs_list))
-
-        return commits, patched_cs, patched_kernels, working_cs

--- a/klpbuild/klplib/plugins.py
+++ b/klpbuild/klplib/plugins.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+import importlib
+import logging
+
+PLUGINS_PATH = "klpbuild.plugins."
+
+def try_run_plugin(name, args):
+    """
+    Attempts to run a plugin by importing the corresponding module and
+    executing its `run` function.
+
+    Args:
+        name (str): The name of the plugin module to import.
+        args (Any): The arguments to pass to the `run` function of the plugin.
+
+    Raises:
+        AssertionError: If the module does not have a `run` function.
+        ModuleNotFoundError: If the specified plugin cannot be found.
+    """
+    logging.debug("Trying to run plugin %s", name)
+
+    module = importlib.import_module(PLUGINS_PATH + name)
+    assert hasattr(module, "run"), f"Module {name} is not a plugin!"
+
+    module.run(args)

--- a/klpbuild/klplib/plugins.py
+++ b/klpbuild/klplib/plugins.py
@@ -7,8 +7,11 @@ import argparse
 import importlib
 import inspect
 import logging
+import pkgutil
 
-PLUGINS_PATH = "klpbuild.plugins."
+
+PLUGINS_PACKAGE_NAME = "klpbuild.plugins"
+PLUGINS_PATH = PLUGINS_PACKAGE_NAME + "."
 
 def try_run_plugin(name, args):
     """
@@ -25,12 +28,24 @@ def try_run_plugin(name, args):
     """
     logging.debug("Trying to run plugin %s", name)
 
-    module = importlib.import_module(PLUGINS_PATH + name)
+    module = __get_plugin(name)
     assert hasattr(module, "run"), f"Module {name} is not a plugin!"
 
     run_func = getattr(module, "run")
     required_args = __get_required_plugin_args(run_func, args)
     run_func(**required_args)
+
+
+def register_plugins_argparser(subparser):
+    """
+    Register the parser of each plugin to the subparser.
+
+    :param subparser: the subparser whose plugin parser will be added
+    """
+    for module in __iter_plugins():
+        # TODO: use 'assert' instead of 'if' when all the plugins are ready
+        if hasattr(module, "register_argparser"):
+            module.register_argparser(subparser)
 
 
 def __get_required_plugin_args(func, args):
@@ -52,3 +67,22 @@ def __get_required_plugin_args(func, args):
     all_args = vars(args)
     required_args_names = inspect.getfullargspec(func).args
     return  {arg_name: all_args.get(arg_name, None) for arg_name in required_args_names}
+
+
+def __iter_plugins():
+    """
+    Iterates plugins.
+
+    """
+    module = importlib.import_module(PLUGINS_PACKAGE_NAME)
+    for _, module_name, _ in pkgutil.iter_modules(module.__path__):
+        yield __get_plugin(module_name)
+
+
+def __get_plugin(name):
+    """
+    Retrieve the plugin given its name.
+
+    :param name: the name of the plugin to be retrieved
+    """
+    return importlib.import_module(PLUGINS_PATH + name)

--- a/klpbuild/klplib/plugins.py
+++ b/klpbuild/klplib/plugins.py
@@ -3,7 +3,9 @@
 # Copyright (C) 2025 SUSE
 # Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
 
+import argparse
 import importlib
+import inspect
 import logging
 
 PLUGINS_PATH = "klpbuild.plugins."
@@ -15,7 +17,7 @@ def try_run_plugin(name, args):
 
     Args:
         name (str): The name of the plugin module to import.
-        args (Any): The arguments to pass to the `run` function of the plugin.
+        args (Any): The main argument parser.
 
     Raises:
         AssertionError: If the module does not have a `run` function.
@@ -26,4 +28,27 @@ def try_run_plugin(name, args):
     module = importlib.import_module(PLUGINS_PATH + name)
     assert hasattr(module, "run"), f"Module {name} is not a plugin!"
 
-    module.run(args)
+    run_func = getattr(module, "run")
+    required_args = __get_required_plugin_args(run_func, args)
+    run_func(**required_args)
+
+
+def __get_required_plugin_args(func, args):
+    """
+    Extracts arguments from an `argparse.Namespace` object and returns only
+    those that are needed as keyword arguments by the function.
+
+    Args:
+        func (function): The name of the plugin module to import.
+        args (ArgumentParser): The main argument parser.
+
+    Raises:
+        AssertionError: If the provided argument is not an instance of
+        `argparse.Namespace`.
+
+    """
+    assert isinstance(args, argparse.Namespace)
+
+    all_args = vars(args)
+    required_args_names = inspect.getfullargspec(func).args
+    return  {arg_name: all_args.get(arg_name, None) for arg_name in required_args_names}

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -38,42 +38,42 @@ def main():
         ffuncs = Setup.setup_file_funcs(args.conf, args.module, args.file_funcs,
                                         args.mod_file_funcs, args.conf_mod_file_funcs)
         codestreams = setup.setup_codestreams(
-            {"cve": args.cve, "conf": args.conf, "lp_filter": args.filter,
+            {"cve": args.cve, "conf": args.conf, "lp_filter": args.lp_filter,
                 "no_check": args.no_check})
         setup.setup_project_files(codestreams, ffuncs, args.archs)
 
     elif args.cmd == "extract":
-        Extractor(args.name, args.filter, args.apply_patches, args.avoid_ext).run()
+        Extractor(args.name, args.lp_filter, args.apply_patches, args.avoid_ext).run()
 
     elif args.cmd == "cs-diff":
-        Extractor(args.name, args.filter, False, []).cs_diff()
+        Extractor(args.name, args.lp_filter, False, []).cs_diff()
 
     elif args.cmd == "check-inline":
         Inliner(args.name, args.codestream).check_inline(args.file, args.symbol)
 
     elif args.cmd == "get-patches":
-        GitHelper(args.filter).get_commits(args.cve, get_workdir(args.name))
+        GitHelper(args.lp_filter).get_commits(args.cve, get_workdir(args.name))
 
     elif args.cmd == "scan":
         GitHelper("").scan(args.cve, args.conf, False)
 
     elif args.cmd == "format-patches":
-        GitHelper(args.filter).format_patches(args.name, args.version)
+        GitHelper(args.lp_filter).format_patches(args.name, args.version)
 
     elif args.cmd == "status":
-        IBS(args.name, args.filter).status(args.wait)
+        IBS(args.name, args.lp_filter).status(args.wait)
 
     elif args.cmd == "push":
-        IBS(args.name, args.filter).push(args.wait)
+        IBS(args.name, args.lp_filter).push(args.wait)
 
     elif args.cmd == "log":
-        IBS(args.name, args.filter).log(args.arch)
+        IBS(args.name, args.lp_filter).log(args.arch)
 
     elif args.cmd == "cleanup":
-        IBS(args.name, args.filter).cleanup()
+        IBS(args.name, args.lp_filter).cleanup()
 
     elif args.cmd == "prepare-tests":
-        IBS(args.name, args.filter).prepare_tests()
+        IBS(args.name, args.lp_filter).prepare_tests()
 
 
 if __name__ == "__main__":

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -54,9 +54,6 @@ def main():
     elif args.cmd == "get-patches":
         GitHelper(args.lp_filter).get_commits(args.cve, get_workdir(args.name))
 
-    elif args.cmd == "scan":
-        GitHelper("").scan(args.cve, args.conf, False)
-
     elif args.cmd == "format-patches":
         GitHelper(args.lp_filter).format_patches(args.name, args.version)
 

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -11,6 +11,7 @@ from klpbuild.klplib.codestreams_data import load_codestreams
 from klpbuild.klplib.ibs import IBS
 from klpbuild.klplib.ksrc import GitHelper
 from klpbuild.klplib.utils import get_workdir
+from klpbuild.klplib.plugins import try_run_plugin
 from klpbuild.plugins.extractor import Extractor
 from klpbuild.plugins.inline import Inliner
 from klpbuild.plugins.setup import Setup
@@ -24,6 +25,14 @@ def main():
     if hasattr(args, 'name'):
         load_codestreams(args.name)
 
+    try:
+        try_run_plugin(args.cmd, args)
+        return
+    except (AssertionError, ModuleNotFoundError):
+        logging.debug("Plugin %s cannot be loaded dinamically!", args.cmd)
+
+    # NOTE: all the code below should be gone when all the modules will be
+    # converted into plugins
     if args.cmd == "setup":
         setup = Setup(args.name)
         ffuncs = Setup.setup_file_funcs(args.conf, args.module, args.file_funcs,

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2021-2024 SUSE
+# Author: Marcos Paulo de Souza <mpdesouza@suse.com
+
+import logging
+import sys
+
+from klpbuild.klplib import utils
+from klpbuild.klplib.ibs import IBS
+from klpbuild.klplib.supported import get_supported_codestreams
+from klpbuild.klplib.ksrc import GitHelper
+
+
+def run(cve, conf, lp_filter, no_check):
+    no_check = False
+
+    return scan(cve, conf, no_check, lp_filter)
+
+def scan(cve, conf, no_check, lp_filter, savedir=None):
+    gh = GitHelper(lp_filter)
+    # Always get the latest supported.csv file and check the content
+    # against the codestreams informed by the user
+    all_codestreams = get_supported_codestreams()
+
+    if not cve or no_check:
+        commits = {}
+        patched_kernels = []
+    else:
+        commits = gh.get_commits(cve, savedir)
+        patched_kernels = gh.get_patched_kernels(all_codestreams, commits, cve)
+
+    # list of codestreams that matches the file-funcs argument
+    working_cs = []
+    patched_cs = []
+    unaffected_cs = []
+    data_missing = []
+    cs_missing = []
+    conf_not_set = []
+
+    if no_check:
+        logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
+
+    for cs in all_codestreams:
+        # Skip patched codestreams
+        if not no_check:
+            if cs.kernel in patched_kernels:
+                patched_cs.append(cs.name())
+                continue
+
+            if not GitHelper.cs_is_affected(cs, cve, commits):
+                unaffected_cs.append(cs)
+                continue
+
+        cs.set_archs()
+
+        if conf and not cs.get_boot_file("config").exists():
+            data_missing.append(cs)
+            cs_missing.append(cs.name())
+            # recheck later if we can add the missing codestreams
+            continue
+
+        if conf and not cs.get_all_configs(conf):
+            conf_not_set.append(cs)
+            continue
+
+        working_cs.append(cs)
+
+    # Found missing cs data, downloading and extract
+    if data_missing:
+        logging.info("Download the necessary data from the following codestreams:")
+        logging.info("\t%s\n", " ".join(cs_missing))
+        IBS("", lp_filter).download_cs_data(data_missing)
+        logging.info("Done.")
+
+        for cs in data_missing:
+            # Ok, the downloaded codestream has the configuration set
+            if cs.get_all_configs(conf):
+                working_cs.append(cs)
+            # Nope, the config is missing, so don't add it to working_cs
+            else:
+                conf_not_set.append(cs)
+
+    if conf_not_set:
+        cs_list = utils.classify_codestreams(conf_not_set)
+        logging.info("Skipping codestreams without %s set:", conf)
+        logging.info("\t%s", " ".join(cs_list))
+
+    if patched_cs:
+        cs_list = utils.classify_codestreams(patched_cs)
+        logging.info("Skipping already patched codestreams:")
+        logging.info("\t%s", " ".join(cs_list))
+
+    if unaffected_cs:
+        cs_list = utils.classify_codestreams(unaffected_cs)
+        logging.info("Skipping unaffected codestreams (missing backports):")
+        logging.info("\t%s", " " .join(cs_list))
+
+    # working_cs will contain the final dict of codestreams that wast set
+    # by the user, avoid downloading missing codestreams that are not affected
+    working_cs = utils.filter_codestreams(lp_filter, working_cs, verbose=True)
+
+    if not working_cs:
+        logging.info("All supported codestreams are already patched. Exiting klp-build")
+        sys.exit(0)
+
+    logging.info("All affected codestreams:")
+    cs_list = utils.classify_codestreams(working_cs)
+    logging.info("\t%s", " ".join(cs_list))
+
+    return commits, patched_cs, patched_kernels, working_cs

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -11,11 +11,27 @@ from klpbuild.klplib.ibs import IBS
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.ksrc import GitHelper
 
+PLUGIN_CMD = "scan"
+
+def register_argparser(subparser):
+    scan = subparser.add_parser(PLUGIN_CMD)
+    scan.add_argument(
+        "--cve",
+        required=True,
+        help="SLE specific. Shows which codestreams are vulnerable to the CVE"
+    )
+    scan.add_argument(
+        "--conf",
+        required=False,
+        help="SLE specific. Helps to check only the codestreams that have this config set."
+    )
+
 
 def run(cve, conf, lp_filter, no_check):
     no_check = False
 
     return scan(cve, conf, no_check, lp_filter)
+
 
 def scan(cve, conf, no_check, lp_filter, savedir=None):
     gh = GitHelper(lp_filter)

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -12,6 +12,7 @@ from klpbuild.klplib import utils
 from klpbuild.klplib.codestreams_data import get_codestreams_data, set_codestreams_data, store_codestreams
 from klpbuild.klplib.ksrc import GitHelper
 
+from klpbuild.plugins.scan import scan
 
 class Setup():
     def __init__(
@@ -60,15 +61,13 @@ class Setup():
         if not self.lp_name.startswith("bsc"):
             raise ValueError("Please use prefix 'bsc' when creating a livepatch for codestreams")
 
-        ksrc = GitHelper(data["lp_filter"])
-
         # Called at this point because codestreams is populated
         # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-        commits, patched_cs, patched_kernels, codestreams = ksrc.scan(data["cve"],
-                                                                      data["conf"],
-                                                                      data["no_check"],
-                                                                      utils.get_workdir(self.lp_name))
-
+        commits, patched_cs, patched_kernels, codestreams = scan(data["cve"],
+                                                                 data["conf"],
+                                                                 data["no_check"],
+                                                                 data["lp_filter"],
+                                                                 utils.get_workdir(self.lp_name))
         # Add new codestreams to the already existing list, skipping duplicates
         old_patched_cs = get_codestreams_data('patched_cs')
         new_patched_cs = natsorted(list(set(old_patched_cs + patched_cs)))

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -3,16 +3,9 @@
 # Copyright (C) 2021-2024 SUSE
 # Author: Marcos Paulo de Souza
 
-import pytest
 from klpbuild.klplib.ksrc import GitHelper
 
 def test_multiline_upstream_commit_subject():
     _, subj = GitHelper.get_commit_data("49c47cc21b5b")
     assert subj == "net: tls: fix possible race condition between do_tls_getsockopt_conf() and do_tls_setsockopt_conf()"
 
-
-# This CVE is already covered on all codestreams
-def test_scan_all_cs_patched(caplog):
-    with pytest.raises(SystemExit):
-        GitHelper("").scan("2022-48801", "", False)
-    assert "All supported codestreams are already patched" not in caplog.text

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2021-2025 SUSE
+# Author: Marcos Paulo de Souza
+
+import pytest
+
+from klpbuild.plugins.scan import scan
+
+# This CVE is already covered on all codestreams
+def test_scan_all_cs_patched(caplog):
+    with pytest.raises(SystemExit):
+        scan("2022-48801", "", False, "")
+    assert "All supported codestreams are already patched" not in caplog.text


### PR DESCRIPTION
This Pull Request introduces the first version of a plugin system, aiming to modularize all commands into standalone plugins.

## Plugin Development Overview

A plugin is nothing else than just a module in the package `klpbuild.plugins` that exposes (at least) two functions:

1. `register_argparser()` : 
    - This function registers the plugin’s command-line arguments.
    - Get the parent parser in the arguments and should add a subparser to it.

3. `run()` : 
    - This function executes the plugin's logic.
    -  It should accept arguments that were registered using the above function `register_argparser()`

    e.g.:
    ```python3
    def run(lp_name, lp_filter):
        pass
    ```

When introducing a plugin, there's no need to modify `klpbuild/main.py` as the plugins are detected at runtime if they have the above mentioned `run` function.

## Internal Workflow
Here’s how the new system processes commands in chronological order:

1. Building the Argument Parser:
    - `create_parser` is called from the main to build the argument parser.
    - `register_plugins_argparser` is called from `create_parser`: this function iterate over all the modules in `klpbuild.plugins` and calls all the `register_argparser()` of each plugin, registering all the subparser in the main parent parser.

2. Executing a plugin:
    - `try_run_plugin` is called from main, it fetches the plugin to run from `klpbuild.plugins` and executes its `run()` function.
    - Before running the plugin, `try_run_plugin` extracts from the parsed arguments only those that concerns this plugin (i.e. those registered via `register_argparser()` and passes them to `run()`.

--- 

With this Pull Request, I also convert the command `scan` to a plugin to give an idea of how the system works. 

Currently, the codebase is hybrid as all the other commands still work in the old way (they are just functions somewhere). As a consequence, in this current state the codebase is messy: the changes required in `klplib/cmd.py` to introduce the per-plugin subparser introduced repetitive code in the function `create_parser`, but it'll be gone when all the command will be converted into plugins. Same for all the if-branches in the main function.

I'm not hundred percent sure this is a good way to go about this plugin subsystem and I'm open to any feedback, please let me know if you would change anything or totally use another solution.

I'm marking this PR as draft: before merging I want to try to convert other commands into plugins to make sure this system works smoothly and without issues, but meanwhile I still appreciate you feedback on this.