### PR TITLE
setup: Add a more advanced versioning schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="klp-build",
-    version="0.0.2",
     author="Marcos Paulo de Souza",
     author_email="mpdesouza@suse.com",
     description="The kernel livepatching creation tool",
@@ -36,5 +35,11 @@ setuptools.setup(
         "filelock",
         "pyelftools",
         "zstandard"
+    ],
+    setuptools_git_versioning={
+        "enabled": True,
+    },
+    setup_requires=[
+        "setuptools-git-versioning>=2.0,<3"
     ],
 )


### PR DESCRIPTION
We are currently using the release `tag` as the only versioning schema; meaning that all commits within the same release share the same version. This obviously poses a limitation for developers working with several builds and who want to keep track of local changes. As such, I propose using the following versioning schema:

For releases: `{tag}`
For each commit after release: `{tag}.post{commit-position}+git.{commit-hash}`
For a commit with unstaged changes: `{same-as-above}.dirty`

The versions will show up when running tests with `tox` and building with `pipx`.