### PR TITLE
codestream: Test if cs.find_obj_path respects the arch passed as argu…

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -271,7 +271,8 @@ class Codestream:
 
     # Return only the name of the module to be livepatched
     def find_obj_path(self, arch, mod):
-        # Return the path is the modules was previously found
+        # Return the path if the modules was previously found for ARCH, or refetch if
+        # the obejct is for a different architecture
         obj = self.modules.get(mod, "")
         if obj:
             assert self.kernel in str(obj)
@@ -279,7 +280,7 @@ class Codestream:
 
         # We already know the path to vmlinux, so return it
         if not is_mod(mod):
-            return self.get_boot_file("vmlinux", arch)
+            return self.get_boot_file("vmlinux", arch).relative_to(get_datadir(arch))
 
         # Module name use underscores, but the final module object uses hyphens.
         mod = mod.replace("_", "[-_]")
@@ -298,7 +299,7 @@ class Codestream:
             if Path(mod_path, obj).exists():
                 break
 
-        return Path(mod_path, obj)
+        return Path(mod_path, obj).relative_to(get_datadir(arch))
 
 
     def lp_out_file(self, lp_name, fname):
@@ -316,7 +317,7 @@ class Codestream:
         cache[arch].setdefault(name, {})
 
         if not cache[arch][name].get(mod, ""):
-            obj = self.find_obj_path(arch, mod)
+            obj = get_datadir(arch)/self.find_obj_path(arch, mod)
             cache[arch][name][mod] = get_all_symbols_from_object(obj, True)
 
         ret = []

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -16,7 +16,7 @@ import zstandard
 from elftools.common.utils import bytes2str
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
-from pathlib import Path, PurePath
+from pathlib import PurePath
 
 from natsort import natsorted
 
@@ -204,8 +204,8 @@ def get_cs_branch(cs, lp_name, git_dir):
     return branch_name
 
 
-def check_module_unsupported(mod_path):
-    elffile = get_elf_object(mod_path)
+def check_module_unsupported(arch, mod_path):
+    elffile = get_elf_object(get_datadir(arch)/mod_path)
     return "no" == get_elf_modinfo_entry(elffile, "supported")
 
 

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -402,7 +402,7 @@ class Extractor():
         env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt else "0"
         env["KCP_MOD_SYMVERS"] = str(cs.get_boot_file("symvers"))
         env["KCP_KBUILD_ODIR"] = str(cs.get_obj_dir())
-        env["KCP_PATCHED_OBJ"] = str(cs.get_mod(fdata["module"]))
+        env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.ARCH)/cs.get_mod(fdata["module"]))
         env["KCP_KBUILD_SDIR"] = str(cs.get_src_dir())
         env["KCP_IPA_CLONES_DUMP"] = str(cs.get_ipa_file(fname))
         env["KCP_WORK_DIR"] = str(out_dir)

--- a/klpbuild/plugins/inline.py
+++ b/klpbuild/plugins/inline.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 
 from klpbuild.klplib.codestreams_data import get_codestreams_dict
-from klpbuild.klplib.utils import filter_codestreams, get_workdir
+from klpbuild.klplib.utils import filter_codestreams, get_datadir, get_workdir, ARCH
 
 
 class Inliner():
@@ -36,7 +36,7 @@ class Inliner():
         if not mod:
             raise RuntimeError(f"File {fname} not in setup phase. Aborting.")
 
-        ce_args.extend(["-debuginfo", str(cs.get_mod(mod))])
+        ce_args.extend(["-debuginfo", str(get_datadir(ARCH)/cs.get_mod(mod))])
 
         # clang-extract works without ipa-clones, so don't hard require it
         ipa_f = cs.get_ipa_file(fname)

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -115,7 +115,7 @@ class Setup():
                 mod_path = cs.find_obj_path(utils.ARCH, mod)
 
                 # Validate if the module being livepatched is supported or not
-                if utils.check_module_unsupported(mod_path):
+                if utils.check_module_unsupported(utils.ARCH, mod_path):
                     logging.warning("%s (%s}): Module %s is not supported by SLE", cs.name(), cs.kernel, mod)
 
                 cs.modules[mod] = str(mod_path)

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -6,7 +6,61 @@
 import pytest
 
 from klpbuild.klplib.codestream import Codestream
+from klpbuild.klplib.utils import ARCHS
+
 
 def test_wrong_cs_filter():
     with pytest.raises(ValueError, match=r"Filter regexp error!"):
         Codestream.from_cs("wrong-filter")
+
+
+def test_find_obj_path_arch():
+    """
+    Ensure the returned obj path doesn't contain any architecture info
+    """
+    cs = Codestream.from_data({
+        "sle": 15,
+        "sp": 5,
+        "update": 15,
+        "rt": "",
+        "project": "SUSE:Maintenance:34200",
+        "patchid": "",
+        "kernel": "5.14.21-150500.55.68",
+        "archs": [
+            "x86_64",
+            "s390x",
+            "ppc64le"
+        ],
+        "files": {
+            "net/sched/sch_taprio.c": {
+                "module": "sch_taprio",
+                "conf": "",
+                "symbols": [
+                        "taprio_change"
+                ],
+                "ext_symbols": {
+                    "sch_taprio": [
+                        "advance_sched",
+                        "parse_taprio_schedule",
+                        "taprio_dequeue_offload",
+                        "taprio_dequeue_soft",
+                        "taprio_free_sched_cb",
+                        "taprio_get_time",
+                        "taprio_offload_free",
+                        "taprio_parse_clockid",
+                        "taprio_peek_offload",
+                        "taprio_peek_soft",
+                        "taprio_policy",
+                        "taprio_set_picos_per_byte"
+                    ]
+                }
+            }
+        },
+        "modules": {
+            "sch_taprio": "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko"
+        },
+        "repo": "SUSE_SLE-15-SP5_Update"
+    })
+
+    for arch in ARCHS:
+        assert arch not in str(cs.find_obj_path(arch, "sch_taprio"))


### PR DESCRIPTION
…ment

The code currently handles a cache to not skip searching the same object path when searching for multiple symbols on different files on the same kernel version.

In this case we can skip the cache if the arch is different from ARCH, which is the one used when creating the cache in the first place.