### PR TITLE
Add pytest dependency when running pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,6 @@ commands =
 description = check code quality
 deps =
     pylint
+    pytest
 commands =
     pylint klpbuild/ tests/


### PR DESCRIPTION
This suppress the following warning when running `pylint`.

```
	Unable to import 'pytest' (import-error)
```