### PR TITLE
Add verbose global option

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -24,6 +24,9 @@ Generic options available for all commands:
 .B "-h, --help"
 Show command's help message and exit.
 .TP
+.B "-v, --verbose"
+Produce more verbose output.
+.TP
 .BI "-n, --name" " NAME"
 The livepatch name. This will be the directory name of the resulting
 livepatches.

--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -33,6 +33,13 @@ def create_parser() -> argparse.ArgumentParser:
     parentparser = argparse.ArgumentParser(add_help=True)
     sub = parentparser.add_subparsers(dest="cmd")
 
+    parentparser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Produce more verbose output"
+    )
+
     register_plugins_argparser(sub)
 
     # NOTE: all the code below should be gone when all the module will be

--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -30,7 +30,7 @@ def add_arg_lp_filter(parentparser, mandatory=False):
 
 
 def create_parser() -> argparse.ArgumentParser:
-    parentparser = argparse.ArgumentParser(add_help=False)
+    parentparser = argparse.ArgumentParser(add_help=True)
     sub = parentparser.add_subparsers(dest="cmd")
 
     register_plugins_argparser(sub)

--- a/klpbuild/klplib/config.py
+++ b/klpbuild/klplib/config.py
@@ -152,7 +152,7 @@ def __load_user_conf():
         logging.warning("Warning: user configuration file not found")
         __setup_user_env(Path.home()/"klp")
 
-    logging.info("Loading user configuration from '%s'", user_conf_file)
+    logging.debug("Loading user configuration from '%s'", user_conf_file)
     _config.read(user_conf_file)
 
     # Check mandatory fields

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -81,7 +81,7 @@ class GitHelper():
 
         # Filter only the branches related to this BSC
         for branch in utils.get_lp_branches(lp_name, kgr_patches):
-            print(branch)
+            logging.info(branch)
             bname = branch.replace(lp_name + "_", "")
             bs = " ".join(bname.split("_"))
             bsc = lp_name.replace("bsc", "bsc#")
@@ -206,7 +206,7 @@ class GitHelper():
 
         self.fetch_kernel_branches()
 
-        print("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
+        logging.info("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 
         # Store all commits from each branch and upstream
         commits = {}
@@ -309,7 +309,7 @@ class GitHelper():
                         stderr=subprocess.STDOUT,
                     ).decode("ISO-8859-1")
                 except subprocess.CalledProcessError:
-                    print(
+                    logging.warn(
                         f"File {fname} doesn't exists {mbranch}. It could "
                         " be removed, so the branch is not affected by the issue."
                     )
@@ -360,16 +360,16 @@ class GitHelper():
         for d, c, msg in ucommits_sort:
             commits["upstream"]["commits"].append(f'{c} ("{msg}")')
 
-        print("")
+        logging.info("")
 
         for key, val in commits.items():
-            print(f"{key}")
+            logging.info(f"{key}")
             branch_commits = val["commits"]
             if not branch_commits:
-                print("None")
+                logging.info("None")
             for c in branch_commits:
-                print(c)
-            print("")
+                logging.info(c)
+            logging.info("")
 
         return commits
 
@@ -451,7 +451,7 @@ class GitHelper():
             logging.info("No CVE informed, skipping the processing of getting the patched kernels.")
             return []
 
-        print("Searching for already patched codestreams...")
+        logging.info("Searching for already patched codestreams...")
 
         kernels = []
 
@@ -475,17 +475,17 @@ class GitHelper():
                 if not patched and kernel not in suse_tags:
                     continue
 
-                print(f"\n{cs.name()} ({kernel}):")
+                logging.debug(f"\n{cs.name()} ({kernel}):")
 
                 # If no patches/commits were found for this kernel, fallback to
                 # the commits in the main SLE branch. In either case, we can
                 # assume that this kernel is already patched.
                 for c in kern_commits if patched else suse_commits:
-                    print(f"{c}")
+                    logging.debug(f"{c}")
 
                 kernels.append(kernel)
 
-        print("")
+        logging.debug("")
 
         # remove duplicates
         return natsorted(list(set(kernels)))

--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -20,7 +20,8 @@ from klpbuild.plugins.setup import Setup
 def main():
     args = create_parser().parse_args(sys.argv[1:])
 
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=logging_level, format="%(message)s")
 
     if hasattr(args, 'name'):
         load_codestreams(args.name)


### PR DESCRIPTION
I believe it's useful to have a global option to enable/disable debugging logs.

I open this a Draft PR so that if you have any other logging call site that would like to convert from `logging.info` to `logging.debug` we can do it in this PR and then merge it.

For instance, I propose to change it when loading the `config` file.