### PR TITLE
Stop catching every assertion error

### DIFF
--- a/klpbuild/main.py
+++ b/klpbuild/main.py
@@ -28,7 +28,12 @@ def main():
     try:
         try_run_plugin(args.cmd, args)
         return
-    except (AssertionError, ModuleNotFoundError):
+    except (AssertionError, ModuleNotFoundError) as e:
+        # TODO: this should be removed as soon as all the modules are converted
+        # into plugins
+        if isinstance(e, AssertionError) and not "is not a plugin!" in str(e):
+                raise
+
         logging.debug("Plugin %s cannot be loaded dinamically!", args.cmd)
 
     # NOTE: all the code below should be gone when all the modules will be


### PR DESCRIPTION
The except clause was introduced to catch assertion errors raised during the stage in charge of loading the plugins and skip those not yet converted so they can use the old machinery.

This can catch every type of assertion error, causing silent exit of the plugins loaded here in case they raise any other assertion error.

Hence filter the only assertion error caused during the loading and re raise all the others.

When all the modules get converted into plugins we should just drop this code and don't catch anything.

fixes: 60725569 ("klplib: plugins: add helper to dynamically load plugins")