### PR TITLE
ci: Trigger klp-build tests only on PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,7 +2,16 @@
 ---
 name: klp-build tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - 'devel'
+      - 'main'
+  push:
+    branches:
+      - '*'
+      - '!devel'
+      - '!main'
 
 jobs:
   distribution-check:


### PR DESCRIPTION
Exclude pushes to 'devel' and 'main'.