### PR TITLE
extract: Get gcc args by using compile_commands.json

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -3,13 +3,17 @@
 # Copyright (C) 2021-2024 SUSE
 # Author: Marcos Paulo de Souza
 
+import json
 import inspect
 import logging
+import pytest
 
 from klpbuild.plugins.extractor import Extractor
 from klpbuild.plugins.setup import setup
+from klpbuild.klplib.codestreams_data import load_codestreams
 from klpbuild.klplib import utils
 
+import tests.utils as tests_utils
 
 def test_detect_file_without_ftrace_support(caplog):
     lp = "bsc_" + inspect.currentframe().f_code.co_name
@@ -29,8 +33,49 @@ def test_detect_file_without_ftrace_support(caplog):
     }
     setup(**setup_args)
 
-
     with caplog.at_level(logging.WARNING):
         Extractor(lp_name=lp, lp_filter=cs, apply_patches=False, avoid_ext=[]).run()
 
     assert "lib/seq_buf.o is not compiled with livepatch support (-pg flag)" in caplog.text
+
+
+def test_compile_commands_enoent():
+    """
+    Check if the extraction fails when a file isn't found on
+    compile_commands.json file
+    """
+
+    lp = "bsc_" + inspect.currentframe().f_code.co_name
+    cs = "15.6u8"
+
+    setup_args = {
+        "lp_name": lp,
+        "lp_filter": cs,
+        "no_check": False,
+        "archs": [utils.ARCH],
+        "cve": None,
+        "conf": "CONFIG_HID",
+        "module": "vmlinux",
+        "file_funcs": [["drivers/hid/hid-core.c", "hid_alloc_report_buf"]],
+        "mod_file_funcs": [],
+        "conf_mod_file_funcs": []
+    }
+    setup(**setup_args)
+
+    # rename the entry on files to a filename that doesn't exists (hid_core.c)
+    data = tests_utils.get_codestreams_file(lp)
+    file_funcs = data["codestreams"][cs]["files"].pop("drivers/hid/hid-core.c")
+    data["codestreams"][cs]["files"]["drivers/hid/hid_core.c"] = file_funcs
+
+    # write back the changed codestreams.json file
+    with open(utils.get_workdir(lp)/"codestreams.json", "r+") as f:
+        f.seek(0)
+        f.write(json.dumps(data, indent=4))
+        f.truncate()
+
+    # reload the codestreams after the change
+    load_codestreams(lp)
+
+    # Now it should fail with hid_core.c that doesn't exists on compile_commands.json
+    with pytest.raises(RuntimeError, match=r"Couldn't find cmdline for drivers/hid/hid_core.c on.*compile_commands.json. Aborting"):
+        Extractor(lp_name=lp, lp_filter=cs, apply_patches=False, avoid_ext=[]).run()


### PR DESCRIPTION
Our make strategy worked well until we found the a new way of getting the gcc arguments used to compile a kernel source file. Recently it started to fail on newer codestreams, failing to find the proper _source_ directory from the -obj directory.

Use this opportunity to finally implement the arguments finding using compile_commands.json that is packaged by kernel-livepatch-default-livepatch-devel rpm.

The paths are extactly the same being found using make, but the instead of the absolute paths to the source directory of the codestreams, the compile_commands.json used '../'. Replacing ../ by the source directory of the affected codestream fixes the problem.