### PR TITLE
Fix paths read from compiler_commands.json

### DIFF
--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -347,10 +347,12 @@ class Extractor():
         for d in data:
             if fname in d["file"]:
                 output = d["command"]
-                # The arguments found on the file point to .., since they are generated
-                # when the kernel is compiled. Replace the .. by the codestream kernel source
-                # directory since klp-ccp needs to reach the files
-                return Extractor.process_make_output(output).replace("..", str(cs.get_src_dir()))
+                # The arguments found on the file point to '..', since they are generated
+                # when the kernel is compiled. Replace the first '..' on each file
+                # path by the codestream kernel source directory since klp-ccp needs to
+                # reach the files.
+                cmd = Extractor.process_make_output(output)
+                return cmd.replace(" ..", f" {str(cs.get_src_dir())}").replace("-I..", f"-I{str(cs.get_src_dir())}")
 
         raise RuntimeError(f"Couldn't find cmdline for {fname} on {str(cc_file)}. Aborting")
 


### PR DESCRIPTION
Any path read from the `compile_commands.json` must be absolute, and if not converted to one. However, to make it absolute, only the first '..' should be replaced by the desired directory path. Any subsequent '..' must be ignored.

Bug triggered with CVE:
```
klp-build setup -n bsc1231196  --cve 2024-46815 --module amdgpu --conf
CONFIG_DRM_AMDGPU --file-func
drivers/gpu/drm/amd/display/dc/clk_mgr/dcn21/rn_clk_mgr.c rn_notify_wm_ranges
--arch x86_64
```

`klp-build extract -n bsc1231196 --apply-patches --filter '15.6rtu2'`