### PR TITLE
Replace sources rpms with kernel.git

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePath
 import re
 
 from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_from_object, get_datadir
-from klpbuild.klplib.kernel_tree import init_cs_kernel_tree
+from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag
 
 class Codestream:
     __slots__ = ("sle", "sp", "update", "rt", "ktype", "needs_ibt", "is_micro",
@@ -75,16 +75,17 @@ class Codestream:
                 self.rt == cs.rt
 
 
-    def get_src_dir(self, arch=ARCH):
+    def get_src_dir(self, arch=ARCH, init=True):
         # Only -rt codestreams have a suffix for source directory
         ktype = self.ktype.replace("-default", "")
         src_dir = get_datadir(arch)/"usr"/"src"/f"linux-{self.kernel}{ktype}"
-        init_cs_kernel_tree(self.kernel, src_dir)
+        if init:
+            init_cs_kernel_tree(self.kernel, src_dir)
         return src_dir
 
 
     def get_obj_dir(self):
-        return Path(f"{self.get_src_dir(ARCH)}-obj", ARCH, self.ktype.replace("-", ""))
+        return Path(f"{self.get_src_dir(ARCH, init=False)}-obj", ARCH, self.ktype.replace("-", ""))
 
 
     def get_ipa_file(self, fname):
@@ -361,6 +362,10 @@ class Codestream:
                 arch_sym[arch] = syms
 
         return arch_sym
+
+
+    def check_file_exists(self, file):
+        file_exists_in_tag(self.kernel, file)
 
 
     def data(self):

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePath
 import re
 
 from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_from_object, get_datadir
+from klpbuild.klplib.kernel_tree import init_cs_kernel_tree
 
 class Codestream:
     __slots__ = ("sle", "sp", "update", "rt", "ktype", "needs_ibt", "is_micro",
@@ -77,7 +78,9 @@ class Codestream:
     def get_src_dir(self, arch=ARCH):
         # Only -rt codestreams have a suffix for source directory
         ktype = self.ktype.replace("-default", "")
-        return get_datadir(arch)/"usr"/"src"/f"linux-{self.kernel}{ktype}"
+        src_dir = get_datadir(arch)/"usr"/"src"/f"linux-{self.kernel}{ktype}"
+        init_cs_kernel_tree(self.kernel, src_dir)
+        return src_dir
 
 
     def get_obj_dir(self):

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -23,8 +23,7 @@ from lxml.objectify import SubElement
 from natsort import natsorted
 from osctiny import Osc
 
-from klpbuild.klplib.codestream import Codestream
-from klpbuild.klplib.codestreams_data import get_codestream_by_name, get_codestreams_dict, get_codestreams_items
+from klpbuild.klplib.codestreams_data import get_codestream_by_name, get_codestreams_dict
 from klpbuild.klplib.config import get_user_path, get_user_settings
 from klpbuild.klplib.utils import ARCH, ARCHS, get_all_symbols_from_object, get_datadir, get_elf_object, get_cs_branch, get_kgraft_branch, filter_codestreams, get_workdir,  get_tests_path, classify_codestreams_str
 

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -140,8 +140,6 @@ class IBS():
 
     def get_cs_packages(self, cs_list, dest):
         # The packages that we search for are:
-        # kernel-source
-        # kernel-devel
         # kernel-(default|rt)
         # kernel-(default|rt)-devel
         # kernel-(default|rt)-livepatch-devel (for SLE15+)
@@ -149,7 +147,6 @@ class IBS():
         # kernel-default-kgraft-devel (for SLE12)
         cs_data = {
             "kernel-default": r"(kernel-(default|rt)\-((livepatch|kgraft)?\-?devel)?\-?[\d\.\-]+.(s390x|x86_64|ppc64le).rpm)",
-            "kernel-source": r"(kernel-(source|devel)(\-rt)?\-?[\d\.\-]+.noarch.rpm)",
         }
 
         rpms = []
@@ -167,8 +164,6 @@ class IBS():
                         # RT kernels have different package names
                         if pkg == "kernel-default":
                             pkg = "kernel-rt"
-                        elif pkg == "kernel-source":
-                            pkg = "kernel-source-rt"
 
                     if cs.repo != "standard":
                         pkg = f"{pkg}.{cs.repo}"
@@ -189,7 +184,7 @@ class IBS():
                         # Extract the source and kernel-devel in the current
                         # machine arch to make it possible to run klp-build in
                         # different architectures
-                        if "kernel-source" in rpm or "kernel-default-devel" in rpm:
+                        if "kernel-default-devel" in rpm:
                             if arch != ARCH:
                                 continue
 

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -5,9 +5,12 @@
 
 import logging
 import os
+import shutil
 import subprocess
 
 from klpbuild.klplib.config import get_user_path
+from klpbuild.klplib.utils import ARCH
+
 
 def init_cs_kernel_tree(kernel_version, outdir):
     """
@@ -35,6 +38,30 @@ def init_cs_kernel_tree(kernel_version, outdir):
         ], stderr=subprocess.PIPE)
 
 
+def cleanup_kernel_trees():
+    """
+    Remove kernel source trees.
+    """
+    kernel_tree = get_user_path("kernel_dir")
+    worktrees = __get_active_worktrees(kernel_tree)
+
+    for wt in worktrees:
+        logging.info("Removing worktree %s", wt)
+        __remove_worktree(kernel_tree, wt)
+
+    # Sometimes when git-worktree is killed during the checkout of the worktree
+    # there are pending sources which are not registered as worktree
+    sources_dir = get_user_path("data_dir")/ARCH/"usr"/"src"
+    for entry in os.listdir(sources_dir):
+        full_path = sources_dir/entry
+        if os.path.isdir(full_path) and not entry.endswith("-obj"):
+            logging.info(f"Removing pending kernel tree: {full_path}")
+            shutil.rmtree(full_path)
+
+    __prune_worktrees(kernel_tree)
+    assert not __get_active_worktrees(kernel_tree)
+
+
 def file_exists_in_tag(kernel_version, file_path):
     """
     Check if a specific file exists in a given kernel version tag.
@@ -52,3 +79,34 @@ def file_exists_in_tag(kernel_version, file_path):
     subprocess.check_output([
         'git',  "-C", kernel_tree, 'ls-tree', kernel_tree_git_tag, file_path
     ], stderr=subprocess.PIPE)
+
+
+def __get_active_worktrees(kernel_tree):
+    data_dir = str(get_user_path("data_dir"))
+    worktrees_output = subprocess.run(["git", "-C", kernel_tree, "worktree", "list"], capture_output=True, text=True)
+
+    worktrees = []
+    for line in worktrees_output.stdout.strip().split("\n"):
+        if data_dir not in line:
+            continue
+        if "prunable" in line:
+            continue
+        worktrees.append(line.split()[0])
+
+    return worktrees
+
+
+def __remove_worktree(kernel_tree, worktree_dir):
+    subprocess.check_output([ "/usr/bin/git", "-C", kernel_tree, "worktree",
+                             "remove", worktree_dir, "-f", "-f"],
+                            stderr=subprocess.PIPE)
+
+    if os.path.isdir(worktree_dir):
+        shutil.rmtree(worktree_dir)
+
+
+def __prune_worktrees(kernel_tree):
+    logging.debug("Pruning pending kernel worktrees")
+    subprocess.check_output([ "/usr/bin/git", "-C", kernel_tree, "worktree",
+                             "prune"],
+                            stderr=subprocess.PIPE)

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -34,3 +34,21 @@ def init_cs_kernel_tree(kernel_version, outdir):
             "add", outdir, "--checkout", kernel_tree_git_tag
         ], stderr=subprocess.PIPE)
 
+
+def file_exists_in_tag(kernel_version, file_path):
+    """
+    Check if a specific file exists in a given kernel version tag.
+
+    Args:
+        kernel_version (str): Kernel version to check.
+        file_path (str): Path of the file to verify.
+
+    Returns:
+        None (raises an error if the file does not exist).
+    """
+    kernel_tree = get_user_path("kernel_dir")
+    kernel_tree_git_tag = "rpm-" + kernel_version
+
+    subprocess.check_output([
+        'git',  "-C", kernel_tree, 'ls-tree', kernel_tree_git_tag, file_path
+    ], stderr=subprocess.PIPE)

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -62,6 +62,19 @@ def cleanup_kernel_trees():
     assert not __get_active_worktrees(kernel_tree)
 
 
+def update_kernel_tree_tags():
+    """
+    Fetch and update the list of tags in the kernel repository.
+    """
+    logging.debug("Updating kernel tree tags..")
+    kernel_tree = get_user_path("kernel_dir")
+    try:
+        subprocess.check_output(['git', "-C", kernel_tree, 'fetch', '--tags'], stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Errors while updating kernel tree tags: %s", e.stderr.decode())
+        logging.error(f"Please fix the issue manually in %s", kernel_tree)
+
+
 def file_exists_in_tag(kernel_version, file_path):
     """
     Check if a specific file exists in a given kernel version tag.

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+import logging
+import os
+import subprocess
+
+from klpbuild.klplib.config import get_user_path
+
+def init_cs_kernel_tree(kernel_version, outdir):
+    """
+    Initialize a kernel source worktree for a specific kernel version.
+
+    This function checks out the appropriate git branch based on the kernel version
+    and creates a worktree in the specified output directory.
+
+    Args:
+        kernel_version (str): Kernel version to check out.
+        outdir (str): Directory where the kernel worktree should be placed.
+    """
+    kernel_tree = get_user_path("kernel_dir")
+    kernel_tree_git_tag = "rpm-" + kernel_version
+
+    # NOTE: here using something like
+    #       if 'outdir' in __get_active_worktrees():
+    # doesn't work. Most likely this is not atomic. Perhaps using a
+    # per-worktree lock would be a better idea
+    if not os.path.isdir(outdir):
+        logging.debug("Checking out source tree: %s", outdir)
+        subprocess.check_output([
+            "/usr/bin/git", "-C", kernel_tree, "worktree",
+            "add", outdir, "--checkout", kernel_tree_git_tag
+        ], stderr=subprocess.PIPE)
+

--- a/klpbuild/plugins/clean_sources.py
+++ b/klpbuild/plugins/clean_sources.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+from klpbuild.klplib.kernel_tree import cleanup_kernel_trees
+
+PLUGIN_CMD = "clean-sources"
+
+def register_argparser(subparser):
+    subparser.add_parser(
+        PLUGIN_CMD, help="Clean extracted sources."
+    )
+
+
+def run():
+    cleanup_kernel_trees()

--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -24,10 +24,12 @@ from klpbuild.klplib import utils
 from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_dict
 from klpbuild.klplib.config import get_user_settings
 from klpbuild.klplib.templ import TemplateGen
+from klpbuild.klplib.kernel_tree import update_kernel_tree_tags
 
 
 class Extractor():
     def __init__(self, lp_name, lp_filter, apply_patches, avoid_ext):
+        update_kernel_tree_tags()
 
         self.lp_name = lp_name
         self.sdir_lock = FileLock(utils.get_datadir()/utils.ARCH/"sdir.lock")

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -165,9 +165,7 @@ def setup_project_files(lp_name, codestreams, ffuncs, archs):
             mod = fdata["module"]
             cs.validate_config(fdata["conf"], mod)
 
-            sdir = cs.get_src_dir()
-            if not Path(sdir, f).is_file():
-                raise RuntimeError(f"{cs.name()} ({cs.kernel}): File {f} not found on {str(sdir)}")
+            cs.check_file_exists(f)
 
             ipa_f = cs.get_ipa_file(f)
             if not ipa_f.is_file():


### PR DESCRIPTION
This pull request modify `klp-build` so that the extractions relies on the `kernel.git` repository instead of the sources rpms.
Each source is no longer downloaded and extracted. Instead a worktree checked out to the respective git tag is created in place of the old source.

This means:
1. `klp-build` no longer downloads the sources rpm for **all** supported codestreams. In this way, setting up the tool for the first time is less time/disk-space consuming .
2. it only allocates a worktree when a specific source is needed for the extraction. The drawback is that when the extraction hits a codestream that doesn't have yet a worktree checked out, it'll take some time to create it.
3. to cleanup space, the command `klp-build clean-sources` will remove all the worktrees. This is useful when there are old trees that we no longer support.

Possible issues:
If for any reason when the worktree creation is interrupted, there might be problem of integrity with the kernel sources. It is recommended to run `klp-build clean-sources` and before the next extraction.

With this PR, a new entry in the config is required, `kernel_dir`, which contains the path to the git kernel repository (expanded tree).

To test the PR it's better to use a new `data_dir` to make sure we're not using old data.