### PR TITLE
ibs: Fix decompression of vmlinux and config for s390x

### DIFF
--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -222,7 +222,7 @@ class IBS():
                 # Extract gzipped files per arch
                 files = ["vmlinux", "symvers"]
                 for f in files:
-                    f_path = cs.get_boot_file(f"{f}.gz")
+                    f_path = cs.get_boot_file(f"{f}.gz", arch)
                     # ppc64le doesn't gzips vmlinux
                     if f_path.exists():
                         subprocess.check_output(rf'gzip -k -d -f {f_path}', shell=True)


### PR DESCRIPTION
klp-build setup does not decompress vmlinux and config files from s390 rpms.

The problem is that cs.get_boot_file() returns x86_64 path by default. Fix it by explicitly passing the arch parameter.