### PR TITLE
scan: Ignore code streams which do not match --filter

### DIFF
--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -4,6 +4,7 @@
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com
 
 import logging
+import re
 import sys
 
 from klpbuild.klplib import utils
@@ -58,6 +59,12 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
         logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
 
     for cs in all_codestreams:
+
+        # Skip filtered code streams
+        if lp_filter and not re.match(lp_filter, cs.name()):
+            logging.debug("	skipping code stream: %s", cs.name())
+            continue
+
         # Skip patched codestreams
         if not no_check:
             if cs.kernel in patched_kernels:


### PR DESCRIPTION
The packages for all code streams are currently downloaded and decompressed even when the caller is interested only into a particular one.

As a result, "klp-build setup" command runs much longer it could. It is not good in production and it makes debugging really painful.

The missing data are collected in scan(). Ignore the filtered code streams there.

IMPORTANT: I am not completely sure that it does not break some workflow. But the following
                        command succeeded with this change and was much faster:

klp-build -v setup --filter 15.3u42 --cve 2024-56600 --name bsc1235218 --conf CONFIG_IPV6 --file-func net/ipv6/af_inet6.c inet6_create