### PR TITLE
More info

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -363,7 +363,11 @@ class GitHelper():
         logging.info("")
 
         for key, val in commits.items():
-            logging.info(f"{key}")
+            if key == "upstream":
+                logging.info(f"{key}")
+            else:
+                logging.info(f"{key}: {self.kernel_branches[key]}")
+
             branch_commits = val["commits"]
             if not branch_commits:
                 logging.info("None")

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -223,6 +223,7 @@ class GitHelper():
         # Since the CVE branch can be some patches "behind" the LTSS branch,
         # it's good to have both backports code at hand by the livepatch author
         for bc, mbranch in self.kernel_branches.items():
+            logging.debug("	processing: %s: %s", bc, mbranch)
             commits[bc] = {"commits": []}
 
             try:


### PR DESCRIPTION
I was running the script a newbie and I missed the following:

  + The connection between the names kernel-source and kgraft-patches branches.
      It might help a bit when we print also the name of the kernel source branch when
      listing the commits for the various code streams.

  + Also getting the information from the kernel-source branches takes a long time.
     It would give me a better feeling when it prints some progress with the -v option.