### PR TITLE
Improve rpms handling

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -48,7 +48,9 @@ class Codestream:
         else:
             assert False, "codestream name should contain either SLE or MICRO!"
 
-        return cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {})
+        ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {})
+        ret.set_archs()
+        return ret
 
 
     @classmethod

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Authors: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+import logging
+
+from klpbuild.klplib.utils import classify_codestreams_str
+from klpbuild.klplib.ibs import IBS
+
+def download_missing_cs_data(codestreams):
+    cs_to_download = __get_cs_missing_data(codestreams)
+    download_cs_data(cs_to_download)
+
+
+def download_cs_data(codestreams):
+    logging.info("Download the necessary data from the following codestreams: %s",
+                 classify_codestreams_str(codestreams))
+    IBS("", "").download_cs_data(codestreams)
+    logging.info("Done.")
+
+
+def __get_cs_missing_data(codestreams):
+    return [cs for cs in codestreams if __is_cs_data_missing(cs)]
+
+
+def __is_cs_data_missing(cs):
+    return not cs.get_boot_file("config").exists()

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -215,6 +215,7 @@ class IBS():
             for arch in cs.archs:
                 # Extract modules and vmlinux files that are compressed
                 mod_path = cs.get_mod_path(arch)
+                logging.info("extracting %s:%s in %s", arch, cs.name(), str(mod_path))
                 for fext, ecmd in [("zst", "unzstd --rm -f -d"), ("xz", "xz --quiet -d -k")]:
                     cmd = rf'find {mod_path} -name "*.{fext}" -exec {ecmd} --quiet {{}} \;'
                     subprocess.check_output(cmd, shell=True)
@@ -225,6 +226,7 @@ class IBS():
                     f_path = cs.get_boot_file(f"{f}.gz", arch)
                     # ppc64le doesn't gzips vmlinux
                     if f_path.exists():
+                        logging.info("extracting %s:%s:%s", arch, cs.name(), f)
                         subprocess.check_output(rf'gzip -k -d -f {f_path}', shell=True)
 
             # Use the SLE .config

--- a/klpbuild/plugins/data.py
+++ b/klpbuild/plugins/data.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+import logging
+
+from klpbuild.klplib.cmd import add_arg_lp_filter
+from klpbuild.klplib.data import download_missing_cs_data, download_cs_data
+from klpbuild.klplib.supported import get_supported_codestreams
+from klpbuild.klplib.utils import filter_codestreams
+
+PLUGIN_CMD = "data"
+
+def register_argparser(subparser):
+    fmt = subparser.add_parser(
+        PLUGIN_CMD, help="Manage codestreams data."
+    )
+
+    add_arg_lp_filter(fmt)
+    fmt.add_argument("--download", required=True, action="store_true",
+                     help="Download all the missing supported codestreams data")
+    fmt.add_argument("--force",action="store_true",
+                     help="Re-download also codestream that are not missing")
+
+
+def run(download, force, lp_filter):
+    supported_codestreams =  get_supported_codestreams()
+    filtered_codestreams = filter_codestreams(lp_filter, supported_codestreams)
+
+    if download:
+        if force:
+            download_cs_data(filtered_codestreams)
+        else:
+            download_missing_cs_data(filtered_codestreams)
+    else:
+        logging.error("Use --download")

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -4,12 +4,11 @@
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com
 
 import logging
-import re
 import sys
 
 from klpbuild.klplib import utils
-from klpbuild.klplib.ibs import IBS
 from klpbuild.klplib.supported import get_supported_codestreams
+from klpbuild.klplib.data import download_missing_cs_data
 from klpbuild.klplib.ksrc import GitHelper
 
 PLUGIN_CMD = "scan"
@@ -40,33 +39,23 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
     # against the codestreams informed by the user
     all_codestreams = get_supported_codestreams()
 
+    # list of codestreams that matches the file-funcs argument
+    working_cs = []
+    patched_cs = []
+    unaffected_cs = []
+    conf_not_set = []
+
     if not cve or no_check:
+        logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
+        working_cs = all_codestreams
         commits = {}
         patched_kernels = []
     else:
         commits = gh.get_commits(cve, savedir)
         patched_kernels = gh.get_patched_kernels(all_codestreams, commits, cve)
 
-    # list of codestreams that matches the file-funcs argument
-    working_cs = []
-    patched_cs = []
-    unaffected_cs = []
-    data_missing = []
-    cs_missing = []
-    conf_not_set = []
+        for cs in utils.filter_codestreams(lp_filter, all_codestreams, verbose=True):
 
-    if no_check:
-        logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
-
-    for cs in all_codestreams:
-
-        # Skip filtered code streams
-        if lp_filter and not re.match(lp_filter, cs.name()):
-            logging.debug("	skipping code stream: %s", cs.name())
-            continue
-
-        # Skip patched codestreams
-        if not no_check:
             if cs.kernel in patched_kernels:
                 patched_cs.append(cs.name())
                 continue
@@ -75,32 +64,21 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
                 unaffected_cs.append(cs)
                 continue
 
-        if conf and not cs.get_boot_file("config").exists():
-            data_missing.append(cs)
-            cs_missing.append(cs.name())
-            # recheck later if we can add the missing codestreams
-            continue
+            working_cs.append(cs)
 
-        if conf and not cs.get_all_configs(conf):
-            conf_not_set.append(cs)
-            continue
-
-        working_cs.append(cs)
-
-    # Found missing cs data, downloading and extract
-    if data_missing:
-        logging.info("Download the necessary data from the following codestreams:")
-        logging.info("\t%s\n", " ".join(cs_missing))
-        IBS("", lp_filter).download_cs_data(data_missing)
-        logging.info("Done.")
-
-        for cs in data_missing:
-            # Ok, the downloaded codestream has the configuration set
-            if cs.get_all_configs(conf):
-                working_cs.append(cs)
-            # Nope, the config is missing, so don't add it to working_cs
-            else:
+    # If conf is set, download the data so we can check for codestreams
+    # containing that configuration.
+    if conf:
+        download_missing_cs_data(working_cs)
+        tmp_working_cs = []
+        for cs in working_cs:
+            # TODO: here we could check for affected arch automatically
+            if not cs.get_all_configs(conf):
                 conf_not_set.append(cs)
+            else:
+                tmp_working_cs.append(cs)
+        working_cs = tmp_working_cs
+
 
     if conf_not_set:
         logging.info("Skipping codestreams without %s set:", conf)
@@ -113,10 +91,6 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
     if unaffected_cs:
         logging.info("Skipping unaffected codestreams (missing backports):")
         logging.info("\t%s", utils.classify_codestreams_str(unaffected_cs))
-
-    # working_cs will contain the final dict of codestreams that wast set
-    # by the user, avoid downloading missing codestreams that are not affected
-    working_cs = utils.filter_codestreams(lp_filter, working_cs, verbose=True)
 
     if not working_cs:
         logging.info("All supported codestreams are already patched. Exiting klp-build")

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -75,8 +75,6 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
                 unaffected_cs.append(cs)
                 continue
 
-        cs.set_archs()
-
         if conf and not cs.get_boot_file("config").exists():
             data_missing.append(cs)
             cs_missing.append(cs.name())

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -25,15 +25,21 @@ def register_argparser(subparser):
         required=False,
         help="SLE specific. Helps to check only the codestreams that have this config set."
     )
+    scan.add_argument(
+        "--download",
+        required=False,
+        action="store_true",
+        help="SLE specific. Download missing codestreams data"
+    )
 
 
-def run(cve, conf, lp_filter, no_check):
+def run(cve, conf, lp_filter, no_check, download):
     no_check = False
 
-    return scan(cve, conf, no_check, lp_filter)
+    return scan(cve, conf, no_check, lp_filter, download)
 
 
-def scan(cve, conf, no_check, lp_filter, savedir=None):
+def scan(cve, conf, no_check, lp_filter, download, savedir=None):
     gh = GitHelper(lp_filter)
     # Always get the latest supported.csv file and check the content
     # against the codestreams informed by the user
@@ -66,10 +72,13 @@ def scan(cve, conf, no_check, lp_filter, savedir=None):
 
             working_cs.append(cs)
 
-    # If conf is set, download the data so we can check for codestreams
-    # containing that configuration.
-    if conf:
+    # Download also if conf is set, because the codestreams data are needed to
+    # check for the configuration entry of each codestreams.
+    if conf or download:
         download_missing_cs_data(working_cs)
+
+    # If conf is set, drop codestream not containing that conf entry from working_cs
+    if conf:
         tmp_working_cs = []
         for cs in working_cs:
             # TODO: here we could check for affected arch automatically

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -133,6 +133,7 @@ def setup_codestreams(lp_name, data):
                                                              data["conf"],
                                                              data["no_check"],
                                                              data["lp_filter"],
+                                                             True,
                                                              utils.get_workdir(lp_name))
     # Add new codestreams to the already existing list, skipping duplicates
     old_patched_cs = get_codestreams_data('patched_cs')

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -10,7 +10,7 @@ from klpbuild.plugins.scan import scan
 # This CVE is already covered on all codestreams
 def test_scan_all_cs_patched(caplog):
     with pytest.raises(SystemExit):
-        scan("2022-48801", "", False, "")
+        scan("2022-48801", "", False, "", False)
 
     assert "All supported codestreams are already patched" in caplog.text
 
@@ -26,7 +26,7 @@ def test_scan_update_ref_commits(caplog):
     klp-build should be able to detect these false-positives and discard them.
     '''
     with pytest.raises(SystemExit):
-        scan("2024-26620", "", False, "")
+        scan("2024-26620", "", False, "", False)
 
     assert "All supported codestreams are already patched" in caplog.text
     assert "b046ad18ee8d6e0df682b28c0dc45056554c5fda" not in caplog.text
@@ -39,7 +39,7 @@ def test_scan_duplicate_commits(caplog):
     the oldest one.
     '''
     with pytest.raises(SystemExit):
-        scan("2021-47511", "", False, "")
+        scan("2021-47511", "", False, "", False)
 
     # Newest (only appears in the cve-5.3 branch)
     assert "094796a2bf2698dc8604dc319736ed207fd09c93" not in caplog.text


### PR DESCRIPTION
The rpms can now be downloaded using the following command instead of having to necessarily run  `setup`:
- `klp-build data --download_missing` to download all the missing codestream data for the supported codestreams;
- `klp-build data --download_force` to force the download even if specific codestreams data are present, in case they got corrupted;

Both the command can be used with `--filter` option.

Nevertheless, although this approach removes the chicken and egg problem, it's still not optimal to download all the missing data for *all* the supported codestreams for anyone who's not a livepatching developer as it will take too much space on disk. So I thought that adding a `--download_data` option to the `scan` command would also solve the problem, as it would download only the data for the codestreams affected by the current `cve`.