### PR TITLE
cmd: Add 'version' command

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -9,6 +9,7 @@
 klp-build \- the kernel livepatching creation tool
 .SH SYNOPSIS
 .B klp-build
+[-h] [-v] [-V]
 <command> [-h] [-n NAME] [--filter FILTER]
 .SH DESCRIPTION
 .B klp-build
@@ -37,6 +38,11 @@ Example: '15\.3u[0-9]+|15\.6u0'
 .br
 You can also use a negative regex in order to filter out a specific codestream.
 Example: '^(?!12.5u12).*'
+.TP
+.B -V, --version
+show
+.BR klp-build 's
+version number and exit.
 .SH COMMANDS
 .TP
 .B scan

--- a/klpbuild/klplib/cmd.py
+++ b/klpbuild/klplib/cmd.py
@@ -4,6 +4,7 @@
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
 import argparse
+import importlib.metadata
 
 from klpbuild.klplib.utils import ARCHS
 from klpbuild.klplib.plugins import register_plugins_argparser
@@ -39,6 +40,13 @@ def create_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="Produce more verbose output"
+    )
+
+    parentparser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"%(prog)s v{importlib.metadata.version('klp-build')}"
     )
 
     register_plugins_argparser(sub)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
         "filelock",
         "pyelftools",
         "zstandard",
-        "python-bugzilla"
+        "python-bugzilla",
+        "importlib"
     ],
     setuptools_git_versioning={
         "enabled": True,


### PR DESCRIPTION
Very simple PR that adds support for a version command. As the name suggest, it prints the current klp-build version.

```
$ klp-build -V
klp-build v0.0.3.post19+git.effd4d63
```