### PR TITLE
Automate patch analysis phase

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,7 +63,7 @@ jobs:
         mkdir -p ~/.config/klp-build &&
         cp tests/config ~/.config/klp-build/ &&
         mkdir -p klp/{livepatches,data} &&
-        tox -e tests -- tests/test_{scan,config,kernel_tree,utils,codestream}.py
+        tox -e tests -- tests/test_{ksrc,scan,config,kernel_tree,utils,codestream}.py
 
     - name: Run pylint
       run: tox -e lint -- --fail-under 9.4 --fail-on F

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -6,7 +6,7 @@
 from pathlib import Path, PurePath
 import re
 
-from klpbuild.klplib.ksrc import ksrc_read_file
+from klpbuild.klplib.ksrc import ksrc_read_file, ksrc_is_module_supported
 from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_from_object, get_datadir
 from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
 
@@ -240,6 +240,8 @@ class Codestream:
     def get_mod(self, mod):
         return self.modules[mod]
 
+    def is_module_supported(self, mod):
+        return ksrc_is_module_supported(mod, self.kernel)
 
     # Returns the path to the kernel-obj's build dir, used when build testing
     # the generated module

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -8,7 +8,7 @@ import re
 
 from klpbuild.klplib.ksrc import ksrc_read_file
 from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_from_object, get_datadir
-from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag
+from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
 
 class Codestream:
     __slots__ = ("sle", "sp", "update", "rt", "ktype", "needs_ibt", "is_micro",
@@ -390,6 +390,8 @@ class Codestream:
     def check_file_exists(self, file):
         return file_exists_in_tag(self.kernel, file)
 
+    def read_file(self, file):
+        return read_file_in_tag(self.kernel, file)
 
     def data(self):
         return {

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -13,10 +13,10 @@ from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag,
 class Codestream:
     __slots__ = ("sle", "sp", "update", "rt", "ktype", "needs_ibt", "is_micro",
                  "project", "patchid", "kernel", "archs", "files", "modules",
-                 "repo")
+                 "repo", "configs")
 
     def __init__(self, sle, sp, update, rt, project, patchid, kernel, archs,
-                 files, modules):
+                 files, modules, configs):
         self.sle = sle
         self.sp = sp
         self.update = update
@@ -30,6 +30,7 @@ class Codestream:
         self.archs = archs
         self.files = files
         self.modules = modules
+        self.configs = configs
         self.repo = self.get_repo()
 
     @classmethod
@@ -50,7 +51,7 @@ class Codestream:
         else:
             assert False, "codestream name should contain either SLE or MICRO!"
 
-        ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {})
+        ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {}, {})
         ret.set_archs()
         return ret
 
@@ -61,14 +62,15 @@ class Codestream:
         if not match:
             raise ValueError("Filter regexp error!")
         return cls(int(match.group(1)), int(match.group(2)),
-                   int(match.group(4)), match.group(3), "", "", "", [], {}, {})
+                   int(match.group(4)), match.group(3), "", "", "", [], {}, {}, {})
 
 
     @classmethod
     def from_data(cls, data):
         return cls(data["sle"], data["sp"], data["update"], data["rt"],
                    data["project"], data["patchid"], data["kernel"],
-                   data["archs"], data["files"], data["modules"])
+                   data["archs"], data["files"], data["modules"],
+                   data["configs"])
 
 
     def __eq__(self, cs):
@@ -405,5 +407,6 @@ class Codestream:
                 "archs" : self.archs,
                 "files" : self.files,
                 "modules" : self.modules,
+                "configs" : self.configs,
                 "repo" : self.repo,
                 }

--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2024 SUSE
+# Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
+#
+# Copied from kernel-source:scripts/file2config.py
+
+import re
+
+from pathlib import Path, PurePath
+from os import chdir
+from argparse import ArgumentParser
+from os.path import expanduser
+
+def _load_makefile(cs, make_file: str) -> list:
+
+    if not cs.check_file_exists(make_file):
+        return []
+
+    buffer = cs.read_file(make_file)
+    assert buffer
+
+    joined = re.sub(r'\\\s*\n[^:]', ' ', buffer)
+
+    lines = joined.split('\n')
+
+    return lines
+
+
+def _sanitize_config(target):
+    config = target.strip('+=').strip().strip('obj-$(){}:').strip()
+    return config
+
+
+def _find_config(cs, obj_path, deep):
+
+    if deep > 10:
+        return None, ""
+
+    make_file = Path(obj_path.parent, "Makefile")
+
+    lines = _load_makefile(cs, make_file)
+
+    obj_name = PurePath(obj_path).name
+    for line in lines:
+        sep = line.split()
+        if obj_name not in sep:
+            continue
+
+        # target found, check if this one with config
+        target = sep[0]
+        if target.startswith('obj-'):
+            return _sanitize_config(target), str(obj_path.with_suffix(''))
+
+        # target contains another object file rule, so strip it would and try
+        # again
+        try:
+            target, _ = target.rsplit('-', 1)
+        except ValueError as ve:
+            # print(ve)
+            continue
+
+        return _find_config(cs, Path(obj_path.parent, target + '.o'), deep + 1)
+
+    return None, ""
+
+
+def find_configs_for_files(cs, file_paths: list):
+
+    configs = dict()
+    build_ins = []
+    missing = []
+
+    if not file_paths:
+        return configs, build_ins, missing
+
+    for path in file_paths:
+        path = path.strip()
+        obj_file = path.replace('.c', '.o')
+        config, obj = _find_config(cs, Path(obj_file), 0)
+        if not config:
+            missing.append(path)
+        elif config == 'y' or config == 'm':
+            build_ins.append(path)
+        elif config.startswith('CONFIG_'):
+            configs[path] = {'config': config, 'obj': obj}
+        # else there is garbage like 'subst', 'vds' for wrongly parsed input
+
+    return configs, build_ins, missing
+

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -138,6 +138,17 @@ def file_exists_in_tag(kernel_version, file_path):
     return len(ret)
 
 
+def read_file_in_tag(kernel_version, file_path):
+
+    kernel_tree = get_user_path("kernel_dir")
+    kernel_tree_git_tag = "rpm-" + kernel_version
+
+    ret = subprocess.run(["git", "-C", kernel_tree, "show",
+                          f"{kernel_tree_git_tag}:{file_path}"],
+                         capture_output=True, text=True)
+    return ret.stdout
+
+
 def __get_active_worktrees(kernel_tree):
     data_dir = str(get_user_path("data_dir"))
     worktrees_output = subprocess.run(["git", "-C", kernel_tree, "worktree", "list"], capture_output=True, text=True)

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -493,7 +493,7 @@ def ksrc_is_module_supported(module, kernel):
         mpath = module
         prev = ""
         idx = 1
-        supported = False
+        supported = True
 
         out = ksrc_read_file(kernel, "supported.conf").splitlines()
         if not out:

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2025 SUSE
+# Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
+
+import logging
+import os
+
+from collections import defaultdict
+
+from klpbuild.klplib import utils
+from klpbuild.klplib.file2config import find_configs_for_files
+from klpbuild.klplib.ksrc import get_commit_files, ksrc_is_module_supported
+
+
+def analyse_files(cs_list, sle_commits):
+    '''
+    Function that analyses, per codestream, each of the files modified
+    by the backported patches.
+    For each of the files it retrieves the corresponding kernel module
+    and config.
+    Lastly, it returns back a report grouping the codestreams by files,
+    modules and configs.
+
+    Args:
+        cs_list (list): List of affected codestreams.
+        sle_commits (dict): List of commits by codestream.
+    '''
+
+    report = defaultdict(list)
+
+    for cs in cs_list:
+        for c in sle_commits[cs.name_cs()]["commits"]:
+            files = get_commit_files(c, inside_patch=True)
+            fconfigs, _, missing = find_configs_for_files(cs, files)
+
+            for file in missing:
+                key = f"{file}::"
+                if cs not in report[key]:
+                    report[key].append(cs)
+
+            for file, dat in fconfigs.items():
+                key = f"{file}:{dat['config']}:{dat['obj']}"
+                if cs not in report[key]:
+                    report[key].append(cs)
+
+            cs.files.update(fconfigs)
+
+    return report
+
+
+def print_files(report):
+
+    for key, cs_list in report.items():
+        cs = cs_list[0]
+        cs_str = utils.classify_codestreams_str(cs_list)
+        file = key.split(':')[0]
+
+        if not cs.files or file not in cs.files:
+            logging.info(f"{cs_str}:\nFILE: {file}\n")
+            continue
+
+        conf = cs.files[file]['config']
+        obj = cs.files[file]['obj']
+        logging.info("%s:\nFILE: %s\nCONF: %s\nOBJ: %s\n",
+                     cs_str, file, conf, obj)
+
+
+def analyse_configs(cs_list):
+    '''
+    Function that analyses, per codestream, each of the CONFIGs found
+    in analyse_files().
+    For each of the CONFIGs it retrieves the archs where they are set,
+    or if they are at all.
+    Lastly, it returns back a report grouping the codestreams by CONFIGs.
+
+    Args:
+        cs_list (list): List of affected codestreams.
+    '''
+
+    report = defaultdict(list)
+
+    for cs in cs_list:
+        for _, dat in cs.files.items():
+            conf = dat['config']
+            if conf in cs.configs:
+                continue
+
+            cs.configs[conf] = cs.get_all_configs(conf)
+
+            key = f"{conf}:{cs.configs[conf]}"
+            if cs not in report[key]:
+                report[key].append(cs)
+
+    return report
+
+
+def __get_arch_config(conf, arch):
+    return conf[arch] if arch in conf else 'n'
+
+
+def print_configs(report):
+
+    for key, cs_list in report.items():
+        cs = cs_list[0]
+        c = key.split(':')[0]
+        conf = cs.configs[c]
+        x86_64 = __get_arch_config(conf, "x86_64")
+        ppc64le = __get_arch_config(conf, "ppc64le")
+        s390x = __get_arch_config(conf, "s390x")
+        cs_str = utils.classify_codestreams_str(cs_list)
+        logging.info("%s:\nCONF: %s\nx86_64: %s\nppc64le: %s\ns390x: %s\n",
+                     cs_str, c, x86_64, ppc64le, s390x)
+
+
+def filter_unset_configs(cs_list):
+
+    unset_cs = []
+    unset_conf = []
+
+    for cs in cs_list:
+        if not cs.configs:
+            continue
+
+        isset = [conf for conf, archs in cs.configs.items() if archs]
+        if not isset:
+            unset_cs.append(cs)
+            unset_conf += [conf for conf in cs.configs]
+
+    for cs in unset_cs:
+        cs_list.remove(cs)
+
+    return unset_cs, sorted(set(unset_conf))
+
+
+def analyse_kmodules(cs_list):
+    '''
+    Function that analyses, per codestream, each of the kernel modules found
+    in analyse_files().
+    For each of the modules it checks if they are supported, builtin and so on.
+    Lastly, it returns back a report grouping the codestreams by modules and
+    their configuration.
+
+    Args:
+        cs_list (list): List of affected codestreams.
+    '''
+
+    report = defaultdict(list)
+
+    for cs in cs_list:
+        for _, dat in cs.files.items():
+            conf = dat['config']
+            mod = dat['obj']
+            if mod in cs.modules:
+                continue
+
+            # Check if it's not built-in for any arch
+            if 'm' not in [val for _, val in
+                           cs.configs[conf].items()]:
+                continue
+
+            supported = cs.is_module_supported(mod)
+            cs.modules[mod] = supported
+            key = f"{mod}:{supported}"
+            if cs not in report[key]:
+                report[key].append(cs)
+
+    return report
+
+
+def print_kmodules(report):
+
+    for key, cs_list in report.items():
+        cs = cs_list[0]
+        m = key.split(':')[0]
+        supported = cs.modules[m]
+        cs_str = utils.classify_codestreams_str(cs_list)
+        logging.info("%s:\nMOD: %s\nSupported: %s\n",
+                     cs_str, m, supported)
+
+
+def filter_unsupported_kmodules(cs_list):
+
+    unset_cs = []
+
+    for cs in cs_list:
+        if not cs.modules:
+            continue
+
+        supported = [s for _, s in cs.modules.items() if s]
+        if not supported:
+            unset_cs.append(cs)
+
+    for cs in unset_cs:
+        cs_list.remove(cs)
+
+    return unset_cs
+

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -34,7 +34,7 @@ def test_find_obj_path_arch():
         "files": {
             "net/sched/sch_taprio.c": {
                 "module": "sch_taprio",
-                "conf": "",
+                "conf": "CONFIG_NET_SCH_TAPRIO",
                 "symbols": [
                         "taprio_change"
                 ],
@@ -59,7 +59,10 @@ def test_find_obj_path_arch():
         "modules": {
             "sch_taprio": "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko"
         },
-        "repo": "SUSE_SLE-15-SP5_Update"
+        "repo": "SUSE_SLE-15-SP5_Update",
+        "configs": {
+            "CONFIG_NET_SCH_TAPRIO": {"x86_64":"m","ppc64le":"m","s390x":"m"}
+            }
     })
 
     for arch in ARCHS:

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2021-2025 SUSE
+# Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
+
+from klpbuild.klplib.ksrc import get_commit_files
+
+def test_get_commit_files():
+    expected = ["include/net/dst_ops.h",
+                "include/net/sock.h",
+                "net/ipv6/route.c",
+                "net/xfrm/xfrm_policy.c"]
+    commit = "604ed28f2720b3354a2eceb530c7e923566f70b8"
+    files = get_commit_files(commit, inside_patch=True)
+    assert len(set(files) & set(expected)) == len(expected)

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2021-2025 SUSE
 # Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
 
-from klpbuild.klplib.ksrc import get_commit_files
+from klpbuild.klplib.ksrc import get_commit_files, ksrc_is_module_supported
 
 def test_get_commit_files():
     expected = ["include/net/dst_ops.h",
@@ -13,3 +13,19 @@ def test_get_commit_files():
     commit = "604ed28f2720b3354a2eceb530c7e923566f70b8"
     files = get_commit_files(commit, inside_patch=True)
     assert len(set(files) & set(expected)) == len(expected)
+
+
+def test_is_module_supported():
+    mod = "drivers/net/wireless/ath/ath12k/ath12k"
+    # Expected: "- drivers/net/wireless/ath/ath12k/ath12k"
+    assert not ksrc_is_module_supported(mod, "6.4.0-20")
+    # Expected: "- drivers/net/wireless/*"
+    assert not ksrc_is_module_supported(mod, "4.12.14-122.255")
+
+    mod = "drivers/net/wireless/intersil/prism54/prism54"
+    # Expected: "-! drivers/net/wireless/intersil/prism54/prism54"
+    assert not ksrc_is_module_supported(mod, "5.14.21-150400.24.144")
+
+    mod = "drivers/net/wireless/mac80211_hwsim"
+    # Expected: "  drivers/net/wireless/mac80211_hwsim"
+    assert ksrc_is_module_supported(mod, "5.14.21-150400.24.144")


### PR DESCRIPTION
Hi team,

This PR automates most of the manual patch analysis done between the `scan` and `setup` commands. It gathers a lot of useful information, saving some time during development.

Full list of features:
- Patch analysis. Retrieve all the files modified by each of the backported patches. Each of those files are also analyzed, gathering the corresponding CONFIG and kernel module.
- Codestream grouping by files, configs and modules.
- klp-build can now check if a module is supported in a specific kernel version (as per the `supported.conf`).
- Better correlation between CONFIGs and modules, per architecture.

Things to be taken into consideration:
 - As a first version, there are probably many corner cases I'm not aware of. 
 - No automated testing yet. As it is already quite a big PR, I'll try to have them on a different one.
 - ~~Relies on the expanded kernel tree or extracted rpm sources.  This can be improved so that it uses the kernel.git repo instead.~~


Example output for a CVE affecting an unsupported kernel module:
```
$ klp-build scan --cve 2024-49931
Downloading codestreams file
Fetching changes from all supported branches...
Getting SUSE fixes for upstream commits per CVE branch. It can take some time...

12.5: SLE12-SP5
None

15.3: SLE15-SP3-LTSS
None

15.4: SLE15-SP4-LTSS
None

15.5: SLE15-SP5-LTSS
None

15.6: SLE15-SP6
e419da4941b0c5e1b4d545528180bfa2fd0341fa

15.6rt: SLE15-SP6-RT
e419da4941b0c5e1b4d545528180bfa2fd0341fa

6.0: SUSE-2024
e419da4941b0c5e1b4d545528180bfa2fd0341fa

6.0rt: SUSE-2024-RT
e419da4941b0c5e1b4d545528180bfa2fd0341fa

cve-5.3: cve/linux-5.3-LTSS
None

cve-5.14: cve/linux-5.14-LTSS
None

upstream
e106b7ad13c1 ("wifi: ath12k: fix array out-of-bound access in SoC stats")

Searching for already patched codestreams...
Checking filter...
Initiating patch analysis...

[*] Analysing modified files...

6.0rtu2-3 6.0u2-3 15.6rtu0-4 15.6u0-5:
FILE: drivers/net/wireless/ath/ath12k/dp_rx.c
CONF: CONFIG_ATH12K
OBJ: drivers/net/wireless/ath/ath12k/ath12k

[*] Analysing required CONFIGs...

6.0rtu2-3 6.0u2-3 15.6rtu0-4:
CONF: CONFIG_ATH12K
x86_64: m
ppc64le: n
s390x: n

15.6u0-5:
CONF: CONFIG_ATH12K
x86_64: m
ppc64le: m
s390x: n

[*] Analysing affected kernel modules...

6.0rtu2-3 6.0u2-3 15.6rtu0-4 15.6u0-5:
MOD: drivers/net/wireless/ath/ath12k/ath12k
Supported: False

Skipping codestreams with unsupported kernel modules:
	6.0rtu2-3 6.0u2-3 15.6rtu0-4 15.6u0-5
Skipping already patched codestreams:
	6.0rtu4 6.0u4 15.6rtu5-9 15.6u6-9
Skipping unaffected codestreams (missing backports):
	12.5u54-66 15.3u42-55 15.4u24-38 15.5u11-24
All supported codestreams are already patched. Exiting klp-build
```
