### PR TITLE
klplib: utils: don't use PurePath in get_tests_path

### DIFF
--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -344,7 +344,7 @@ def get_tests_path(lp_name):
         # For more complex tests we support using a directory containing
         # as much files as needed. A `test_script.sh` is still required
         # as an entry point.
-        return PurePath(test_dir_sh).parent
+        return Path(test_dir_sh).parent
 
     logging.warning("No testscript found for %s", lp_name)
     return None


### PR DESCRIPTION
PurePath doesn't have is_file(), so prepare-test fails when the test script is contained in a directory