### PR TITLE
scan: Filter codestreams with no-check enabled

### DIFF
--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -56,7 +56,7 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
 
     if not cve or no_check:
         logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
-        working_cs = all_codestreams
+        working_cs = utils.filter_codestreams(lp_filter, all_codestreams)
         commits = {}
         patched_kernels = []
     else:


### PR DESCRIPTION
Scan was ignoring the filtered codestreams when running with 'no-check' enabled.
The t`est_valite_conf_unsupported_arch` was failing because it expected a filtered codestream-related output. 