### PR TITLE
setup.py: Remove importlib as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setuptools.setup(
         "filelock",
         "pyelftools",
         "zstandard",
-        "python-bugzilla",
-        "importlib"
+        "python-bugzilla"
     ],
     setuptools_git_versioning={
         "enabled": True,


### PR DESCRIPTION
importlib is part of python3, and leaving this depency here makes it fail to be installed on openSUSE Tumbleweed.