### PR TITLE
klplib: kernel_tree: use decorator to update kernel tree tags

### DIFF
--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -24,12 +24,10 @@ from klpbuild.klplib import utils
 from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_dict
 from klpbuild.klplib.config import get_user_settings
 from klpbuild.klplib.templ import TemplateGen
-from klpbuild.klplib.kernel_tree import update_kernel_tree_tags
 
 
 class Extractor():
     def __init__(self, lp_name, lp_filter, apply_patches, avoid_ext):
-        update_kernel_tree_tags()
 
         self.lp_name = lp_name
         self.sdir_lock = FileLock(utils.get_datadir()/utils.ARCH/"sdir.lock")

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -10,7 +10,6 @@ from klpbuild.klplib import utils
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.data import download_missing_cs_data
 from klpbuild.klplib.ksrc import GitHelper
-from klpbuild.klplib.kernel_tree import update_kernel_tree_tags
 
 PLUGIN_CMD = "scan"
 
@@ -45,8 +44,6 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
     # Always get the latest supported.csv file and check the content
     # against the codestreams informed by the user
     all_codestreams = get_supported_codestreams()
-
-    update_kernel_tree_tags()
 
     # list of codestreams that matches the file-funcs argument
     working_cs = []


### PR DESCRIPTION
So we don't have to remember every time we use the kernel tree in a new part of the codebase :) 