### PR TITLE
extractor: Call update_kernel_tree_tags after the attrs are defined

### DIFF
--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -29,7 +29,6 @@ from klpbuild.klplib.kernel_tree import update_kernel_tree_tags
 
 class Extractor():
     def __init__(self, lp_name, lp_filter, apply_patches, avoid_ext):
-        update_kernel_tree_tags()
 
         self.lp_name = lp_name
         self.sdir_lock = FileLock(utils.get_datadir()/utils.ARCH/"sdir.lock")
@@ -113,6 +112,7 @@ class Extractor():
         self.env["KCP_READELF"] = "readelf"
         self.env["KCP_RENAME_PREFIX"] = "klp"
 
+        update_kernel_tree_tags()
 
     def __del__(self):
         if self.sdir_lock:


### PR DESCRIPTION
Otherwise, if the git command that is called on update_kernel_tree_tags fails, the following error happens:

Traceback (most recent call last):
  File "/home/mpdesouza/.local/bin/klp-build", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/mpdesouza/.local/pipx/venvs/klp-build/lib64/python3.11/site-packages/klpbuild/main.py", line 44, in main
    Extractor(args.lp_name, args.lp_filter, False, []).cs_diff()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mpdesouza/.local/pipx/venvs/klp-build/lib64/python3.11/site-packages/klpbuild/plugins/extractor.py", line 32, in __init__
    update_kernel_tree_tags()
  File "/home/mpdesouza/.local/pipx/venvs/klp-build/lib64/python3.11/site-packages/klpbuild/klplib/kernel_tree.py", line 93, in update_kernel_tree_tags
    subprocess.check_output(['git', "-C", kernel_tree, 'fetch', '--tags', '--force', '--quiet'],
  File "/usr/lib64/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', '-C', PosixPath('/home/mpdesouza/git/suse/kernel'), 'fetch', '--tags', '--force', '--quiet']' returned non-zero exit status 128.
Exception ignored in: <function Extractor.__del__ at 0x7f8f02eaf6a0>
Traceback (most recent call last):
  File "/home/mpdesouza/.local/pipx/venvs/klp-build/lib64/python3.11/site-packages/klpbuild/plugins/extractor.py", line 118, in __del__
    if self.sdir_lock:
       ^^^^^^^^^^^^^^
AttributeError: 'Extractor' object has no attribute 'sdir_lock'

This happens because the self.sdir_lock is defined right after update_kernel_tree_tags was being called. Make sure this doesn't happen again by calling update_kernel_tree_tags as the last thing being done on Extractor constructor.