### PR TITLE
klplib: codestream: use ksrc to read config

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -441,3 +441,12 @@ def cs_is_affected(cs, cve, commits):
 
     return len(commits[cs.name_cs()]["commits"]) > 0
 
+
+def ksrc_read_file(kernel_version, file_path):
+    ksrc_dir = get_user_path("kernel_src_dir")
+    ksrc_tag = "rpm-" + kernel_version
+
+    ret = subprocess.run(["git", "-C", ksrc_dir, "show",
+                          f"{ksrc_tag}:{file_path}"],
+                         capture_output=True, text=True)
+    return ret.stdout


### PR DESCRIPTION
This PR is a prerequisite for #110 .

Please @fgyanz , notice that I have copied the `read_file_in_tag` function from you PR and moved in `klplib/utils` so that it can be used both from `ksrc` and `kernel_tree`.