### PR TITLE
klplib/ksrc: Filter out merge commits

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -232,6 +232,8 @@ def get_commits(cve, savedir=None):
                         "-C",
                         kern_src,
                         "log",
+                        "--full-history",
+                        "--remove-empty",
                         "--numstat",
                         "--reverse",
                         "--no-merges",
@@ -257,6 +259,10 @@ def get_commits(cve, savedir=None):
 
                 # Skip the Update commits, that only change the References tag
                 if "Update" in hash_entry and "patches.suse" in hash_entry:
+                    continue
+
+                # Skip any merge commit that git's --no-merge failed to filter out
+                if "Merge branch" in hash_entry:
                     continue
 
                 # Skip commits that change one single line. Most likely just a

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -4,6 +4,7 @@
 # Author: Marcos Paulo de Souza
 
 import pytest
+import re
 
 from klpbuild.plugins.scan import scan
 
@@ -45,3 +46,16 @@ def test_scan_duplicate_commits(caplog):
     assert "094796a2bf2698dc8604dc319736ed207fd09c93" not in caplog.text
     # Oldest
     assert "69603451953a96fe87621abc34b771c41be859be" in caplog.text
+
+def test_scan_merge_commits(caplog):
+    '''
+    The CVE has a related merge commit. klp-build should skip it
+    and only show the commits introducing the patches.
+    '''
+    scan("2024-35905", "", False, "", False)
+
+    assert "6959d874bc4db32ad6baa18779a145204576b5b8" not in caplog.text
+    rt= ("6.0rt: SUSE-2024-RT\n.*"
+        "72c76c85224ee4c8e51c77d6c407401f6935508d\n.*"
+        "5fa3c1186f44343ae6130db7f10c5284da78b461\n")
+    assert re.search(rt, caplog.text)


### PR DESCRIPTION
In some cases git-log incorrectly reports back the commit that merged the branch containing the expected commit, and not the expected commit itself. This happens even with the "--no-merge" flag enabled, so there's no choice but to skip them manually.

Also, in order to find the commit that introduced the patch, from now on git-log will be forced to follow all the parent commits and traverse the full patch's history, until file creation. This is a more exhaustive method, and as such slower than before (~4 second slowdown).

I'd like to point out that the ideal git-log flag would be `--follow`, but unfortunately it's just too slow for our propose  (~1:32min). Hence, the second best option, `full-history`.