### PR TITLE
-Wno-dangling-pointer removal

### DIFF
--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -382,6 +382,7 @@ class Extractor():
             "-mindirect-branch-cs-prefix",
             "-mharden-sls=all",
             "-fmin-function-alignment=16",
+            "-Wno-dangling-pointer",
         ]:
             cmd = cmd.replace(opt, "")
 


### PR DESCRIPTION
Again klp-ccp is too slow to keep up with the gcc flags used by "modern" kernels, so we need to do something on our side, otherwise we can't produce livepatches.