### PR TITLE
klplib: ibs: Fix download_and_extract new tuple element

### DIFF
--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -217,7 +217,7 @@ def download_binary_rpms(args, total):
 
 
 def download_and_extract(args, total):
-    i, cs, _, _, arch, _, rpm, dest = args
+    _, i, cs, _, _, arch, _, rpm, dest = args
 
     # Try to download and extract at least twice if any problems arise
     tries = 2


### PR DESCRIPTION
This is needed otherwise it will fail whenever we need to download any rpms on setup phase.