### PR TITLE
extractor.py: Ignore 'make' errors

### DIFF
--- a/klpbuild/plugins/extractor.py
+++ b/klpbuild/plugins/extractor.py
@@ -163,6 +163,7 @@ class Extractor():
             make_args = [
                 "make",
                 "-sn",
+                "--ignore-errors",
                 f"CC={cc}",
                 f"KLP_CS={cs.name()}",
                 f"HOSTCC={cc}",


### PR DESCRIPTION
Ignore errors as long as we manage to get back the correct make commands for the target object.
This PR is a workaround to allow klp-build work on older distributions where "make" was failing.