### PR TITLE
klplib: Support new MICRO rt-kernels versioning

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -48,6 +48,8 @@ class Codestream:
         # MICRO-6-0_Update_2
         elif "MICRO" in cs:
             sle, sp, u = cs.replace("MICRO-", "").replace("-RT", "").replace("_Update_", "-").split("-")
+            if rt and int(u) >= 5:
+                kernel = kernel + "-rt"
         else:
             assert False, "codestream name should contain either SLE or MICRO!"
 
@@ -82,8 +84,8 @@ class Codestream:
 
     def get_src_dir(self, arch=ARCH, init=True):
         # Only -rt codestreams have a suffix for source directory
-        ktype = self.ktype.replace("-default", "")
-        src_dir = get_datadir(arch)/"usr"/"src"/f"linux-{self.kernel}{ktype}"
+        name = self.kname() if self.rt else self.kernel
+        src_dir = get_datadir(arch)/"usr"/"src"/f"linux-{name}"
         if init:
             init_cs_kernel_tree(self.kernel, src_dir)
         return src_dir
@@ -149,7 +151,7 @@ class Codestream:
 
 
     def kname(self):
-        return self.kernel + self.ktype
+        return self.kernel + ("" if "-rt" in self.kernel else self.ktype)
 
 
     def name(self):

--- a/tests/supported.csv
+++ b/tests/supported.csv
@@ -1,8 +1,10 @@
 Update ID,Maintenance Project,Kernel version,Supported until,LTSS until
 MICRO-6-0-RT_Update_2,SUSE:ALP:Source:Standard:Core:1.0:Build/patchinfo.20240906153916876714.90520734224245,6.4.0-10.1,only LTSS supported,
 MICRO-6-0-RT_Update_3,SUSE:ALP:Source:Standard:Core:1.0:Build/patchinfo.20241017135808025064.90520734224245,6.4.0-11.1,only LTSS supported,
+MICRO-6-0-RT_Update_5,SUSE:SLFO:Kernel:1.0:Build/patchinfo.20250214125327899694.90520734224245,6.4.0-25.1,only LTSS supported,
 MICRO-6-0_Update_2,SUSE:ALP:Source:Standard:Core:1.0:Build/patchinfo.20240905161518457739.90520734224245,6.4.0-19.1,only LTSS supported,
 MICRO-6-0_Update_3,SUSE:ALP:Source:Standard:Core:1.0:Build/patchinfo.20241015104416836583.269002615871826,6.4.0-20.1,only LTSS supported,
+MICRO-6-0_Update_5,SUSE:SLFO:Kernel:1.0:Build/patchinfo.20250309130943729455.90520734224245,6.4.0-25.1,only LTSS supported,
 SLE15-SP3_Update_41,SUSE:Maintenance:32513,5.3.18-150300.59.150.1,only LTSS supported,2025-03-14
 SLE15-SP3_Update_42,SUSE:Maintenance:32895,5.3.18-150300.59.153.2,only LTSS supported,2025-04-13
 SLE15-SP3_Update_43,SUSE:Maintenance:33221,5.3.18-150300.59.158.1,only LTSS supported,2025-06-03


### PR DESCRIPTION
klp-build works under the assumption that each kernel version is unique and corresponds to one single codestreams. However, from now on, that won't be the case for newer Micro rt-kernels, that will have the same version as their non-rt counterparts. Luckily, this kernels will still have a unique tag in kernel-source.git and kernel.git: "rpm-$kernel-rt", and "rpm-$kernel" for the non-rt.

Within klp-build the above idea will be used too, and any new Micro rt-kernel version will have the "-rt" suffix appended to it (e.g. "6.4.0-25-rt"). By doing this we keep the uniqueness of the versions.

There is no way to put it kindly, but this workaround is as nasty as it can get. Unfortunately, other solutions required re-working much more codebase and the effort was not worth IMHO. 