### PR TITLE
setup: Make --cve cmdline option mandatory

### DIFF
--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -52,12 +52,13 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
     conf_not_set = []
     unsupported = []
 
-    if not cve or no_check:
+    if no_check:
         logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
         working_cs = utils.filter_codestreams(lp_filter, all_codestreams)
         commits = {}
         patched_kernels = []
     else:
+        assert cve
         commits = get_commits(cve, savedir)
         patched_kernels = get_patched_kernels(all_codestreams, commits, cve)
 

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -22,7 +22,7 @@ def register_argparser(subparser):
     )
     add_arg_lp_name(setup)
     add_arg_lp_filter(setup)
-    setup.add_argument("--cve", type=str, help="The CVE assigned to this livepatch")
+    setup.add_argument("--cve", type=str, required=True, help="The CVE assigned to this livepatch")
     setup.add_argument("--conf", type=str, required=True, help="The kernel CONFIG used to be build the livepatch")
     setup.add_argument(
         "--no-check",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -10,7 +10,7 @@ from tests.utils import get_codestreams_file
 from klpbuild.klplib import utils
 
 CS = "15.5u19"
-DEFAULT_DATA = {"cve": None, "lp_filter": CS, "conf": "CONFIG_TUN", "no_check": False}
+DEFAULT_DATA = {"cve": None, "lp_filter": CS, "conf": "CONFIG_TUN", "no_check": True}
 
 
 def test_missing_file_funcs():
@@ -94,7 +94,7 @@ def test_valid_micro_patchid():
     # Make sure that patchid is informed for SLE MICRO
     lp = "bsc_" + inspect.currentframe().f_code.co_name
     micro_cs = "6.0u2"
-    micro_data = {"cve": None, "lp_filter": micro_cs, "conf": "CONFIG_TUN", "no_check": False}
+    micro_data = {"cve": None, "lp_filter": micro_cs, "conf": "CONFIG_TUN", "no_check": True}
 
     setup_args = {
         "lp_name" : lp,
@@ -143,7 +143,7 @@ def test_valite_conf_unsupported_arch():
     lp = "bsc_" + inspect.currentframe().f_code.co_name
 
     # CONFIG_HID is not enabled on s390x, so setup should fail here
-    LP_DEFAULT_DATA = {"cve": None, "lp_filter": CS, "conf": "CONFIG_HID", "no_check": False}
+    LP_DEFAULT_DATA = {"cve": None, "lp_filter": CS, "conf": "CONFIG_HID", "no_check": True}
     with pytest.raises(RuntimeError, match=rf"{CS}: CONFIG_HID not set on s390x"):
         setup_args = {
             "lp_name": lp,


### PR DESCRIPTION
The --cve option is not mandatory in the setup command simply due to testing convenience, breaking the consistency with the rest of commands.

From now on --cve will be mandatory in setup, except when using --no-check option.