### PR TITLE
klplib: Improve error handling of git-fetch

### DIFF
--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -42,8 +42,12 @@ def __fetch_kernel_tree_tags():
     """
     logging.debug("Updating kernel tree tags..")
     kernel_tree = get_user_path("kernel_dir")
-    subprocess.check_output(['git', "-C", kernel_tree, 'fetch', '--tags', '--force', '--quiet'],
-                            stderr=subprocess.PIPE)
+    ret = subprocess.run(['git', "-C", kernel_tree, 'fetch', '--tags', '--force', '--quiet'],
+                         stderr=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+                         text=True)
+    if ret.returncode:
+        logging.info("Failed to update kernel tree tags\n%s", ret.stderr)
 
 # Currently this function returns the date of the patch and its subject
 @__check_kernel_tags_are_fetched

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -69,11 +69,18 @@ def __fetch_kernel_branches():
     kern_src = get_user_path('kernel_src_dir')
     logging.info("Fetching changes from all supported branches...")
 
-    if not utils.in_test_mode():
-        # Mount the command to fetch all branches for supported codestreams
-        subprocess.check_output(["/usr/bin/git", "-C", str(kern_src), "fetch",
-                                 "--quiet", "--atomic", "--force", "--tags", "origin"] +
-                                list(KERNEL_BRANCHES.values()))
+    if utils.in_test_mode():
+        return
+
+    # Mount the command to fetch all branches for supported codestreams
+    ret = subprocess.run(["/usr/bin/git", "-C", str(kern_src), "fetch",
+                          "--quiet", "--atomic", "--force", "--tags", "origin"] +
+                         list(KERNEL_BRANCHES.values()),
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         text=True)
+    if ret.returncode:
+        logging.info("Fetch failed\n%s", ret.stderr)
 
 
 def diff_commits(base, new, patch, pattern=""):


### PR DESCRIPTION
Avoid crashing and better handle git errors when fetching kernel-source.git and kernel.git repositories.