### PR TITLE
klplib/ksrc: Improve handling of multi-file commits

### DIFF
--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -30,6 +30,11 @@ def analyse_files(cs_list, sle_commits):
 
     for cs in cs_list:
         for c in sle_commits[cs.name_cs()]["commits"]:
+            # Skip the commit if it touches more than two patches.
+            if  len(get_commit_files(c)) > 2:
+                logging.warn("Skipping commit %s: Too many files\n", c)
+                continue
+
             files = get_commit_files(c, inside_patch=True)
             fconfigs, _, missing = find_configs_for_files(cs, files)
 


### PR DESCRIPTION
klp-build has some trouble processing commits affecting hundreds of patches. Such commits usually get ignored because they are mostly about re-naming or re-organizing the repository tree. But in certain cases, though extremely uncommon, they might be the only way of tracking some patches, and must therefore be kept during the heuristic phase.