### PR TITLE
tests: Set --no-check option when no CVE is needed

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -22,7 +22,7 @@ def test_detect_file_without_ftrace_support(caplog):
     setup_args = {
         "lp_name" : lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs" : [utils.ARCH],
         "cve": None,
         "conf": "CONFIG_SMP",
@@ -51,7 +51,7 @@ def test_compile_commands_enoent():
     setup_args = {
         "lp_name": lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs": [utils.ARCH],
         "cve": None,
         "conf": "CONFIG_HID",
@@ -88,7 +88,7 @@ def test_detect_opt_clone(caplog):
     setup_args = {
         "lp_name": lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs": [utils.ARCH],
         "cve": None,
         "conf": "CONFIG_BT",

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -10,7 +10,7 @@ from klpbuild.klplib.ibs import get_cs_packages
 from klpbuild.plugins.setup import setup_codestreams
 
 CS = "15.6u0"
-DEFAULT_DATA = {"cve": None, "lp_filter": CS, "lp_skips": None, "conf": None, "no_check": False}
+DEFAULT_DATA = {"cve": None, "lp_filter": CS, "lp_skips": None, "conf": None, "no_check": True}
 
 
 def test_list_of_packages():

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -18,7 +18,7 @@ def test_templ_with_externalized_vars():
     setup_args = {
         "lp_name" : lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs" : utils.ARCHS,
         "cve": None,
         "conf": "CONFIG_PROC_FS",
@@ -61,7 +61,7 @@ def test_templ_without_externalized_vars():
     setup_args = {
         "lp_name" : lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs" : [utils.ARCH],
         "cve": None,
         "conf": "CONFIG_IPV6",
@@ -108,7 +108,7 @@ def test_check_header_file_included():
     setup_args = {
         "lp_name" : lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs" : utils.ARCHS,
         "cve": None,
         "conf": "CONFIG_IPV6",
@@ -262,7 +262,7 @@ def test_templ_ibt_without_externalized_vars():
     setup_args = {
         "lp_name" : lp,
         "lp_filter": cs,
-        "no_check": False,
+        "no_check": True,
         "archs" : utils.ARCHS,
         "cve": None,
         "conf": "CONFIG_IPV6",


### PR DESCRIPTION
Some tests were failing because they were still following the old policy