### PR TITLE
New heuristic

### DIFF
--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -19,7 +19,7 @@ class CodestreamData:
     archs: list[str]
     patched_kernels: list[str]
     patched_cs: list[str]
-    commits: dict[str, str]
+    upstream: list[str]
 
 
 _cs_data = CodestreamData("", [], [], [], {})
@@ -44,7 +44,7 @@ def load_codestreams(lp_name):
                                           archs=jfile["archs"],
                                           patched_kernels=jfile["patched_kernels"],
                                           patched_cs=jfile["patched_cs"],
-                                          commits=jfile["commits"])
+                                          upstream=jfile["upstream"])
 
             json_cs = jfile["codestreams"]
             for cs in natsorted(json_cs.keys()):
@@ -69,7 +69,7 @@ def store_codestreams(lp_name, working_cs):
         cs_data[key] = cs.data()
 
     data = {"archs": _cs_data.archs,
-            "commits": _cs_data.commits,
+            "upstream": _cs_data.upstream,
             "cve": _cs_data.cve,
             "patched_cs": _cs_data.patched_cs,
             "patched_kernels": _cs_data.patched_kernels,

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -83,67 +83,24 @@ def __fetch_kernel_branches():
         logging.info("Fetch failed\n%s", ret.stderr)
 
 
-def diff_commits(base, new, patch, pattern=""):
+def get_patch_files(patches, branch):
     """
-    Check if there's any difference between the two given commits.
+    Get the kernel files that have been modified by the give list of patches.
 
     Args:
-        base (str): Commit to use as base in the diff.
-        new (str): Commit to compare with the base.
-        patch (list): Target files in the diff.
+        patches (list): Input list of patches to analyse.
+        branch (str): Branch where to locate the given patches.
 
     returns:
-        Boolean: True if both commits differ. False otherwise.
+        List: Return the files modified by the given patches.
     """
     kern_src = get_user_path('kernel_src_dir')
-
-    if base == "":
-        return True
-
-    # Compare lines starting with '+' or '-'.
-    # This should be enough to ignore sneaky metadata updates on
-    # the file and duplicated commits.
-    diff = subprocess.run(["/usr/bin/git", "-C", kern_src, "diff",
-                           "--numstat", pattern, base, new,
-                           "--", str(patch)],
-                          stdout = subprocess.DEVNULL,
-                          stderr = subprocess.DEVNULL)
-
-    return diff.returncode
-
-
-def get_commit_files(commit, inside_patch=False, regex=r"patches\.suse\/.+\.patch"):
-    """
-    Get the files that have been modified in one specific commit or
-    within the patch files of the commit.
-    Optionally only get those that match the given regular expression.
-
-    Args:
-        commit (str): The commit to be anylized.
-        regex (str): Optional regex.
-        inside_path (bool): True for getting the files modified by the
-        patch file in the commit. False for just getting the files in the
-        commit.
-
-    returns:
-        List: Return the files that match the regex, if set. Otherwise,
-        return all the files.
-    """
-    kern_src = get_user_path('kernel_src_dir')
-
-    ret = subprocess.check_output(["/usr/bin/git", "-C", kern_src,
-                                   "diff-tree", "--no-commit-id", "--name-only",
-                                   commit, "-r"]).decode()
-
-    patches = re.findall(regex, ret) if regex else ret.splitlines()
-    if not inside_patch:
-        return patches
 
     files = []
     for p in patches:
         ret = subprocess.check_output(["/usr/bin/git", "-C", kern_src,
-                                       "grep", "-Ih", "^+++", commit,
-                                       "--", p]).decode()
+                                       "grep", "-Ih", "^+++",
+                                       f"remotes/origin/{branch}:{p}"]).decode()
         for l in ret.splitlines():
             # Remove the first caracters "+++ [a,b]/" in the line. Leftovers
             # from the patch's diff.
@@ -167,7 +124,8 @@ def get_branch_patches(cve, mbranch):
 
     try:
         patch_files = subprocess.check_output(
-            ["/usr/bin/git", "-C", kern_src, "grep", "-l", f"CVE-{cve}", f"remotes/origin/{mbranch}"],
+            ["/usr/bin/git", "-C", kern_src, "grep", "-l", f"CVE-{cve}",
+             f"remotes/origin/{mbranch}", "--", "patches.suse/"],
             stderr=subprocess.STDOUT,
         ).decode(sys.stdout.encoding)
     except subprocess.CalledProcessError:
@@ -188,80 +146,11 @@ def get_branch_patches(cve, mbranch):
     except subprocess.CalledProcessError:
         patch_files = ""
 
-    # The command above returns a list of strings in the format
-    #   branch:file/path
     return patch_files.splitlines()
 
 
-def get_branch_commits(mbranch, patch):
-
-    kern_src = get_user_path('kernel_src_dir')
-
-    # Now get all commits related to that file on that branch,
-    # including the "Refresh" ones.
-    try:
-        phashes = subprocess.check_output(
-            [
-                "/usr/bin/git",
-                "-C",
-                kern_src,
-                "log",
-                "--full-history",
-                "--remove-empty",
-                "--numstat",
-                "--reverse",
-                "--no-merges",
-                "--pretty=oneline",
-                f"remotes/origin/{mbranch}",
-                "--",
-                patch,
-            ],
-            stderr=subprocess.STDOUT,
-        ).decode("ISO-8859-1")
-    except subprocess.CalledProcessError:
-        return []
-
-    iphashes = iter(phashes.splitlines())
-    base = ""
-    commits = []
-    for hash_entry in iphashes:
-        stats = next(iphashes)
-
-        # Skip the Update commits, that only change the References tag
-        if "Update" in hash_entry and "patches.suse" in hash_entry:
-            continue
-
-        # Skip any merge commit that git's --no-merge failed to filter out
-        if "Merge branch" in hash_entry:
-            continue
-
-        # Skip commits that change one single line. Most likely just a
-        # reference update.
-        if stats.split()[0] == "1":
-            continue
-
-        hash_commit = hash_entry.split(" ")[0]
-
-        # Sometimes we can have a commit that touches two files. In
-        # these cases we can have duplicated hash commits, since git
-        # history for each individual file will show the same hash.
-        # Skip if the same hash already exists.
-        if hash_commit in commits:
-            continue
-
-        diff = diff_commits(base, hash_commit, patch, r"-G'^\+|^-'")
-        # Skip commit if the file's content is the same as the previous one.
-        if not diff:
-            continue
-
-        base = hash_commit
-        commits.append(hash_commit)
-
-    return commits
-
-
 @__check_kernel_source_tags_are_fetched
-def get_commits(cve, savedir=None):
+def get_patches(cve, savedir=None):
     kern_src = get_user_path('kernel_src_dir', isopt=True)
     if not kern_src:
         logging.info("kernel_src_dir not found, skip getting SUSE commits")
@@ -279,23 +168,20 @@ def get_commits(cve, savedir=None):
 
     logging.info("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 
-    # Store all commits from each branch and upstream
-    commits = {}
-    # List of upstream commits, in creation date order
-    ucommits = []
+    # Store all patches from each branch and upstream
+    patches = {}
+    patches["upstream"] = []
+    # Temporal list of upstream commits
+    upstream = set()
 
     upstream_patches_dir = None
     if savedir:
         upstream_patches_dir = Path(savedir)/"upstream"
         upstream_patches_dir.mkdir(exist_ok=True, parents=True)
 
-    # Get backported commits from all possible branches, in order to get
-    # different versions of the same backport done in the CVE branches.
-    # Since the CVE branch can be some patches "behind" the LTSS branch,
-    # it's good to have both backports code at hand by the livepatch author
     for bc, mbranch in KERNEL_BRANCHES.items():
-        logging.debug("	processing: %s: %s", bc, mbranch)
-        commits[bc] = {"commits": []}
+        logging.debug("	processing %s:%s", bc, mbranch)
+        patches[bc] = []
 
         idx = 0
         for patch in get_branch_patches(cve, mbranch):
@@ -319,125 +205,37 @@ def get_commits(cve, savedir=None):
             ups = ""
             m = re.search(r"Git-commit: ([\w]+)", pfile)
             if m:
-                ups = m.group(1)[:12]
+                c = m.group(1)[:12]
+                d, msg = get_commit_data(c, upstream_patches_dir)
+                upstream.add((d, c, msg))
 
-            # Aggregate all upstream fixes found
-            if ups and ups not in ucommits:
-                ucommits.append(ups)
+            patches[bc].append(patch)
 
-            c = get_branch_commits(mbranch, patch)
-            if c:
-                commits[bc]["commits"] = list(set(c + commits[bc]["commits"]))
-            else:
-                commits[bc]["commits"] = []
-
-    # Grab each commits subject and date for each commit. The commit dates
-    # will be used to sort the patches in the order they were
-    # created/merged.
-    ucommits_sort = []
-    for c in ucommits:
-        d, msg = get_commit_data(c, upstream_patches_dir)
-        ucommits_sort.append((d, c, msg))
-
-    ucommits_sort.sort()
-    commits["upstream"] = {"commits": []}
-    for d, c, msg in ucommits_sort:
-        commits["upstream"]["commits"].append(f'{c} ("{msg}")')
-
-    logging.info("")
-
-    for key, val in commits.items():
+    for key, bc_patches in patches.items():
         if key == "upstream":
-            logging.info(f"{key}")
-        else:
-            logging.info(f"{key}: {KERNEL_BRANCHES[key]}")
+            continue
 
-        branch_commits = val["commits"]
-        if not branch_commits:
+        logging.info(f"{key}: {KERNEL_BRANCHES[key]}")
+
+        if not bc_patches:
             logging.info("None")
-        for c in branch_commits:
+        for c in bc_patches:
             logging.info(c)
         logging.info("")
 
-    return commits
+    logging.info(f"upstream")
+    for _, c, msg in sorted(upstream):
+        fmt = f'{c} ("{msg}")'
+        patches["upstream"].append(fmt)
+        logging.info(fmt)
 
-def get_patched_tags(suse_commits):
-    tag_commits = {}
-    patched = []
-    total_commits = len(suse_commits)
-    kern_src = get_user_path('kernel_src_dir')
+    logging.info("")
 
-    # Grab only the first commit, since they would be put together
-    # in a release either way. The order of the array is backards, the
-    # first entry will be the last patch found.
-    for su in suse_commits:
-        tag_commits[su] = []
+    return patches
 
-        tags = subprocess.check_output(["/usr/bin/git", "-C", kern_src,
-                                        "tag", f"--contains={su}",
-                                        "rpm-*"])
 
-        for tag in tags.decode().splitlines():
-            # Remove noise around the kernel version, like
-            # rpm-5.3.18-150200.24.112--sle15-sp2-ltss-updates
-            if "--" in tag:
-                continue
-
-            tag = tag.replace("rpm-", "")
-            tag_commits.setdefault(tag, [])
-            tag_commits[tag].append(su)
-
-        # "patched branches" are those who contain all commits
-        for tag, b in tag_commits.items():
-            if len(b) == total_commits:
-                patched.append(tag)
-
-    # remove duplicates
-    return natsorted(list(set(patched)))
-
-def is_kernel_patched(kernel, suse_commits, cve):
-    commits = []
-
-    kern_src = get_user_path('kernel_src_dir')
-    ret = subprocess.check_output(["/usr/bin/git", "-C", kern_src, "log",
-                                   f"--grep=CVE-{cve}",
-                                   f"--tags=*rpm-{kernel}",
-                                   "--format='%at-%H-%s'"]).decode().splitlines()
-    # Sort by date
-    ret.sort(reverse=True)
-
-    for line in ret:
-        # Skip the Update commits, that only change the References tag
-        if "Update" in line and "patches.suse" in line:
-            continue
-
-        # Parse commit's hash
-        c = line.split("-")[1]
-
-        files = get_commit_files(c)
-        nfiles = len(files)
-        if nfiles == 0:
-            continue
-
-        # Match 1:1 with the commits found in SLE branch
-        for s in suse_commits:
-            if nfiles <= 500:
-                diff = diff_commits(s, c, files)
-                if not diff:
-                    # Found same commit
-                    commits.append(c)
-                    break
-            else:
-                # Do not diff commits with too many files.
-                if nfiles == len(get_commit_files(s)):
-                    commits.append(c)
-                    break
-
-    # "patched kernels" are those which contain all commits.
-    return len(suse_commits) == len(commits), commits
-
-def get_patched_kernels(codestreams, commits, cve):
-    if not commits:
+def get_patched_kernels(codestreams, patches, cve):
+    if not patches:
         return []
 
     kern_src = get_user_path('kernel_src_dir', isopt=True)
@@ -451,52 +249,38 @@ def get_patched_kernels(codestreams, commits, cve):
 
     logging.info("Searching for already patched codestreams...")
 
-    kernels = []
+    kernels = set()
 
-    for bc, _ in KERNEL_BRANCHES.items():
-        suse_commits = commits[bc]["commits"]
-        if not suse_commits:
+    for cs in codestreams:
+        bc = cs.name().split("u")[0]
+        suse_patches = patches[bc]
+        if not suse_patches:
             continue
 
-        # Get all the kernels/tags containing the commits in the main SLE
-        # branch. This information alone is not reliable enough to decide
-        # if a kernel is patched.
-        suse_tags = get_patched_tags(suse_commits)
-
         # Proceed to analyse each codestream's kernel
-        for cs in codestreams:
-            if bc+'u' not in cs.name():
-                continue
+        kernel = cs.kernel
 
-            kernel = cs.kernel
-            patched, kern_commits = is_kernel_patched(kernel, suse_commits, cve)
-            if not patched and kernel not in suse_tags:
-                continue
-
-            logging.debug(f"\n{cs.name()} ({kernel}):")
-
-            # If no patches/commits were found for this kernel, fallback to
-            # the commits in the main SLE branch. In either case, we can
-            # assume that this kernel is already patched.
-            for c in kern_commits if patched else suse_commits:
-                logging.debug(f"{c}")
-
-            kernels.append(kernel)
+        logging.debug(f"\n{cs.name()} ({kernel}):")
+        for patch in suse_patches:
+            if not ksrc_read_rpm_file(kernel, patch):
+                break
+            logging.debug(f"{patch}")
+        else:
+            kernels.add(kernel)
 
     logging.debug("")
 
-    # remove duplicates
-    return natsorted(list(set(kernels)))
+    return kernels
 
 
-def cs_is_affected(cs, cve, commits):
+def cs_is_affected(cs, cve, patches):
     # We can only check if the cs is affected or not if the CVE was informed
     # (so we can get all commits related to that specific CVE). Otherwise we
     # consider all codestreams as affected.
     if not cve:
         return True
 
-    return len(commits[cs.name_cs()]["commits"]) > 0
+    return len(patches[cs.name_cs()]) > 0
 
 
 def ksrc_read_rpm_file(kernel_version, file_path):

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -9,10 +9,10 @@ from collections import defaultdict
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.file2config import find_configs_for_files
-from klpbuild.klplib.ksrc import get_commit_files
+from klpbuild.klplib.ksrc import KERNEL_BRANCHES, get_patch_files
 
 
-def analyse_files(cs_list, sle_commits):
+def analyse_files(cs_list, sle_patches):
     '''
     Function that analyses, per codestream, each of the files modified
     by the backported patches.
@@ -29,13 +29,10 @@ def analyse_files(cs_list, sle_commits):
     report = defaultdict(list)
 
     for cs in cs_list:
-        for c in sle_commits[cs.name_cs()]["commits"]:
-            # Skip the commit if it touches more than two patches.
-            if  len(get_commit_files(c)) > 2:
-                logging.warn("Skipping commit %s: Too many files\n", c)
-                continue
-
-            files = get_commit_files(c, inside_patch=True)
+            bc = cs.name_cs()
+            patches = sle_patches[bc]
+            branch = KERNEL_BRANCHES[bc]
+            files = get_patch_files(patches, branch)
             fconfigs, _, missing = find_configs_for_files(cs, files)
 
             for file in missing:

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -79,46 +79,11 @@ ${get_protos(proto_syms)}
 """
 
 TEMPL_SUSE_HEADER = """\
-<%
-def get_commits(cmts, cs):
-    if not cmts.get(cs, ''):
-        return ' *  Not affected'
-
-    ret = []
-    for commit, msg in cmts[cs].items():
-        if not msg:
-            ret.append(' *  Not affected')
-        else:
-            for m in msg:
-                ret.append(f' *  {m}')
-
-    return "\\n".join(ret)
-%>\
 /*
  * ${fname}
  *
  * Fix for CVE-${cve}, bsc#${lp_num}
  *
-% if include_header:
- *  Upstream commit:
-${get_commits(commits, 'upstream')}
- *
- *  SLE12-SP5 commit:
-${get_commits(commits, '12.5')}
- *
- *  SLE15-SP3 commit:
-${get_commits(commits, 'cve-5.3')}
- *
- *  SLE15-SP4 and -SP5 commit:
-${get_commits(commits, '15.4')}
- *
- *  SLE15-SP6 commit:
-${get_commits(commits, '15.6')}
- *
- *  SLE MICRO-6-0 commit:
-${get_commits(commits, '6.0')}
- *
-% endif
  *  Copyright (c) ${year} SUSE
  *  Author: ${ user } <${ email }>
  *
@@ -513,7 +478,7 @@ class TemplateGen():
         user, email = get_mail()
         tvars = {
             "check_enabled": self.check_enabled,
-            "commits": get_codestreams_data('commits'),
+            "upstream": get_codestreams_data('upstream'),
             "config": "CONFIG_CHANGE_ME",
             "cve": cve,
             "email": email,
@@ -598,9 +563,7 @@ def create_kbuild(lp_name, cs):
 
 
 def generate_commit_msg_file(lp_name):
-    cmts = get_codestreams_data('commits').get("upstream", {})
-    if cmts:
-        cmts = cmts["commits"]
+    cmts = get_codestreams_data('upstream')
     cve = get_codestreams_data('cve')
     if not cve:
         cve = "XXXX-XXXX"

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -130,7 +130,7 @@ def setup_codestreams(lp_name, data):
 
     # Called at this point because codestreams is populated
     # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-    commits, patched_cs, patched_kernels, codestreams = scan(data["cve"],
+    upstream, patched_cs, patched_kernels, codestreams = scan(data["cve"],
                                                              data["conf"],
                                                              data["no_check"],
                                                              data["lp_filter"],
@@ -140,7 +140,8 @@ def setup_codestreams(lp_name, data):
     old_patched_cs = get_codestreams_data('patched_cs')
     new_patched_cs = natsorted(list(set(old_patched_cs + patched_cs)))
 
-    set_codestreams_data(commits=commits, patched_kernels=patched_kernels,
+    set_codestreams_data(upstream=upstream,
+                         patched_kernels=list(patched_kernels),
                          patched_cs=new_patched_cs, cve=data['cve'])
     return codestreams
 

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -3,16 +3,16 @@
 # Copyright (C) 2021-2025 SUSE
 # Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
 
-from klpbuild.klplib.ksrc import (get_commit_files, ksrc_is_module_supported,
-                                  get_branch_patches, get_branch_commits)
+from klpbuild.klplib.ksrc import (get_patch_files, ksrc_is_module_supported,
+                                  get_branch_patches)
 
 def test_get_commit_files():
     expected = ["include/net/dst_ops.h",
                 "include/net/sock.h",
                 "net/ipv6/route.c",
                 "net/xfrm/xfrm_policy.c"]
-    commit = "604ed28f2720b3354a2eceb530c7e923566f70b8"
-    files = get_commit_files(commit, inside_patch=True)
+    patch = ["patches.suse/net-fix-__dst_negative_advice-race.patch"]
+    files = get_patch_files(patch, "SLE15-SP6")
     assert len(set(files) & set(expected)) == len(expected)
 
 
@@ -38,15 +38,3 @@ def test_get_rt_patches():
             ]
     patches = get_branch_patches("2024-35905", "SUSE-2024-RT")
     assert patches and expected == patches
-
-def test_get_merge_commits():
-    '''
-    The CVE has a related merge commit. klp-build should skip it
-    and only show the commits introducing the patches.
-    '''
-
-    expected = ["5fa3c1186f44343ae6130db7f10c5284da78b461"]
-    patch = "patches.suse/bpf-Protect-against-int-overflow-for-stack-access-si.patch"
-    commits = get_branch_commits("SUSE-2024-RT", patch)
-    assert commits and expected == commits
-    assert "6959d874bc4db32ad6baa18779a145204576b5b8" not in commits

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -14,34 +14,3 @@ def test_scan_all_cs_patched(caplog):
 
     assert "All supported codestreams are already patched" in caplog.text
 
-def test_scan_update_ref_commits(caplog):
-    '''
-    The CVE has several related commits updating the patch's "Reference".
-    The commits' message might lead to false-positives:
-    ```
-    Update
-    patches.suse/s390-vfio-ap-always-filter-entire-AP-matrix.patch
-    (git-fixes bsc#1218988 CVE-2024-26620 bsc#1221298).
-     ```
-    klp-build should be able to detect these false-positives and discard them.
-    '''
-    with pytest.raises(SystemExit):
-        scan("2024-26620", "", False, "", False)
-
-    assert "All supported codestreams are already patched" in caplog.text
-    assert "b046ad18ee8d6e0df682b28c0dc45056554c5fda" not in caplog.text
-    assert "4fb9779c0bb7188d837df9e43e6f84d067d0efd4" not in caplog.text
-
-def test_scan_duplicate_commits(caplog):
-    '''
-    The CVE has two identical commits intrudicing the same patch for the
-    same SLE (15.3). klp-build should discard the newest commit and keep
-    the oldest one.
-    '''
-    with pytest.raises(SystemExit):
-        scan("2021-47511", "", False, "", False)
-
-    # Newest (only appears in the cve-5.3 branch)
-    assert "094796a2bf2698dc8604dc319736ed207fd09c93" not in caplog.text
-    # Oldest
-    assert "69603451953a96fe87621abc34b771c41be859be" in caplog.text

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -123,18 +123,6 @@ def test_check_header_file_included():
 
     extract(lp_name=lp, lp_filter=cs, apply_patches=False, avoid_ext=[])
 
-    # test the livepatch_ prefix file
-    assert "Upstream commit:" in get_file_content(lp, cs)
-
-    # Check for all supported codestreams
-    for item in ["SLE12-SP5", "SLE15-SP3", "SLE15-SP4 and -SP5",
-                 "SLE15-SP6", "SLE MICRO-6-0"]:
-        assert item in get_file_content(lp, cs)
-
-    # Check the other two files
-    assert "Upstream commit:" not in get_file_content(lp, cs, f"{lp}_kernel_events_core.c")
-    assert "Upstream commit:" not in get_file_content(lp, cs, f"{lp}_net_ipv6_rpl.c")
-
     # Check that for file kernel/events/core.c there are externalized symbols, so the prototype
     # of init/cleanup are created on header
     # As net/ipv6/rpl.c there are no externalized symbols we expect that it's prototype isn't


### PR DESCRIPTION
The current design for finding whether a kernel is patched or not
is extremely slow and inefficient. It relies heavily on git commits,
which inevitably requires processing the full log history of each
kernel branch/tag.

A simpler yet still effective design would be to just check if
the kernel branch/tag has the patch file in ./patches.suse/.

There might be some corner cases, such as patch renaming, but
it would be trivial to workaround those issues. What's more,
this approach is quite fast and requires much less code.

The most notable side-effect from this new design is in the livepatch templates.

```

 * Fix for CVE-2024-26809, bsc#1245771
 *
 *  Upstream commit:
 *  b0e256f3dd2b
 *
 *  SLE12-SP5 patches:
 *  Not affected
 *
 *  SLE15-SP3 patch:
 *  Not affected
 *
 *  SLE15-SP4 and -SP5 patches:
 *  Not affected
 *
 *  SLE15-SP6 patches:
 *  patches.suse/netfilter-nft_set_pipapo-release-elements-in-clone-o.patch
 *
 *  SLE MICRO-6-0 patches:
 *  patches.suse/netfilter-nft_set_pipapo-release-elements-in-clone-o.patch
```
No commits, just patches names.

As for the `klp-build scan` command:
```
12.5: SLE12-SP5
None

15.3: SLE15-SP3-LTSS
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.4: SLE15-SP4-LTSS
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.5: SLE15-SP5-LTSS
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.6: SLE15-SP6
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.6rt: SLE15-SP6-RT
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.7: SLE15-SP7
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

15.7rt: SLE15-SP7-RT
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

6.0: SUSE-2024
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

6.0rt: SUSE-2024-RT
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

cve-5.3: cve/linux-5.3-LTSS
None

cve-5.14: cve/linux-5.14-LTSS
patches.suse/drm-dp_mst-Ensure-mst_primary-pointer-is-valid-in-dr.patch

Updating kernel tree tags..
upstream
e54b00086f74 ("drm/dp_mst: Ensure mst_primary pointer is valid in drm_dp_mst_handle_up_req()")
```