### PR TITLE
fix module regex matching in modules.order

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -316,7 +316,7 @@ class Codestream:
 
         mod_path = self.get_mod_path(arch)
         with open(Path(mod_path, "modules.order")) as f:
-            obj_match = re.search(rf"([\w\/\-]+\/{mod}.k?o)", f.read())
+            obj_match = re.search(rf"([\w\/\-]+\/{mod}\.k?o)", f.read())
             if not obj_match:
                 raise RuntimeError(f"{self.name()}-{arch} ({self.kernel}): Module not found: {mod}")
 


### PR DESCRIPTION
mod="vsock"
re.search(rf"([\w\/\-]+\/{mod}.k?o)", f.read())
gives:
 <_sre.SRE_Match object; span=(51942, 51968), match='kernel/drivers/net/vsockmo'>

While with the fix
re.search(rf"([\w\/\-]+\/{mod}\\.k?o)", f.read())
gives:
 <_sre.SRE_Match object; span=(190408, 190437), match='kernel/net/vmw_vsock/vsock.ko'>