### PR TITLE
Refactor codestream

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -23,10 +23,11 @@ class Codestream:
         match = re.search(r"(\d+)\.(\d+)(rt)?u(\d+)", name)
         if not match:
             raise ValueError("Name format error")
+        assert match.group(3) in (None, "rt")
 
         self.sle = int(match.group(1))
         self.sp = int(match.group(2))
-        self.rt = match.group(3)
+        self.rt = match.group(3) or ""
         self.update = int(match.group(4))
 
         self.is_micro = self.sle == 6
@@ -175,8 +176,7 @@ class Codestream:
         Return the base codestream name, optionally including 'rt' if it's a
         real-time kernel.
         """
-        rt = "rt" if self.rt else ""
-        return f"{self.sle}.{self.sp}{rt}"
+        return f"{self.sle}.{self.sp}{self.rt}"
 
 
     def full_cs_name(self):

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -11,9 +11,8 @@ from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_fro
 from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
 
 class Codestream:
-    __slots__ = ("sle", "sp", "update", "rt", "ktype", "is_micro",
-                 "project", "patchid", "kernel", "archs", "files", "modules",
-                 "repo", "configs")
+    __slots__ = ("sle", "sp", "update", "rt", "is_micro", "project", "patchid",
+                 "kernel", "archs", "files", "modules", "repo", "configs")
 
     def __init__(self, sle, sp, update, rt, project="", patchid="", kernel="",
                  archs=None, files=None, modules=None, configs=None):
@@ -21,7 +20,6 @@ class Codestream:
         self.sp = sp
         self.update = update
         self.rt = rt
-        self.ktype = "-rt" if rt else "-default"
         self.is_micro = sle == 6
         self.project = project
         self.patchid = patchid
@@ -104,7 +102,7 @@ class Codestream:
 
 
     def get_obj_dir(self):
-        return Path(f"{self.get_src_dir(ARCH, init=False)}-obj", ARCH, self.ktype.replace("-", ""))
+        return Path(f"{self.get_src_dir(ARCH, init=False)}-obj", ARCH, self.get_kernel_type())
 
 
     def get_ipa_file(self, fname):
@@ -117,7 +115,7 @@ class Codestream:
         rpms, but this difference should not affect the entries that
         enable/disable portion of the source.
         """
-        file = f"config/{arch}/rt" if self.rt else f"config/{arch}/default"
+        file = f"config/{arch}/{self.get_kernel_type()}"
         return ksrc_read_rpm_file(self.kernel, file)
 
     def get_boot_file(self, file, arch=ARCH):
@@ -162,10 +160,16 @@ class Codestream:
         self.files = files
 
 
+    def get_kernel_type(self, suffix=False):
+        dash = "-" if suffix else ""
+        suffix = "rt" if self.rt else "default"
+        return dash + suffix
+
+
     def get_full_kernel_name(self):
         """Returns the kernel name with flavor suffix"""
         # some kernel versions already have the suffix, some other don't
-        ktype = "" if "-rt" in self.kernel else self.ktype
+        ktype = "" if "-rt" in self.kernel else self.get_kernel_type(suffix=True)
         return self.kernel + ktype
 
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -208,20 +208,33 @@ class Codestream:
         fpath = f'work_{str(fname).replace("/", "_")}'
         return self.get_ccp_dir(lp_name)/fpath
 
-    def name_full(self):
-        # Parse 15.2u25 to SLE15-SP2_Update_25
-        # Parse 6.0u2 to MICRO
+
+    def get_base_product_name(self):
+        """
+        Return the base product name based on internal attributes.
+
+        Example:
+            15.6rtu2:       'SLE15-SP6-RT'
+            6u0:            'MICRO-6-0'
+        """
+        rt = "-RT" if self.rt else ""
+
         if self.is_micro:
-            buf = f"MICRO-{self.sle}-{self.sp}"
-        else:
-            buf = f"SLE{self.sle}"
-            if int(self.sp) > 0:
-                buf = f"{buf}-SP{self.sp}"
+            return f"MICRO-{self.sle}-{self.sp}{rt}"
 
-        if self.rt:
-            buf = f"{buf}-RT"
+        return f"SLE{self.sle}-SP{self.sp}{rt}"
 
-        return f"{buf}_Update_{self.update}"
+
+    def get_full_product_name(self):
+        """
+        Return the full product name including the update number.
+
+        Example:
+            15.6rtu2:       'SLE15-SP6-RT_Update_0'
+            6u0:            'MICRO-6-0_Update_0'
+        """
+        product_base_name = self.get_base_product_name()
+        return f"{product_base_name}_Update_{self.update}"
 
 
     # 15.4 onwards we don't have module_mutex, so template generates

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -84,7 +84,7 @@ class Codestream:
 
     def get_src_dir(self, arch=ARCH, init=True):
         # Only -rt codestreams have a suffix for source directory
-        name = self.kname() if self.rt else self.kernel
+        name = self.get_full_kernel_name() if self.rt else self.kernel
         src_dir = get_datadir(arch)/"usr"/"src"/f"linux-{name}"
         if init:
             init_cs_kernel_tree(self.kernel, src_dir)
@@ -114,7 +114,7 @@ class Codestream:
             return Path(self.get_mod_path(arch), file)
 
         # Strip the suffix from the filename so we can add the kernel version in the middle
-        fname = f"{Path(file).stem}-{self.kname()}{Path(file).suffix}"
+        fname = f"{Path(file).stem}-{self.get_full_kernel_name()}{Path(file).suffix}"
         return get_datadir(arch)/"boot"/fname
 
     def get_repo(self):
@@ -150,8 +150,11 @@ class Codestream:
         self.files = files
 
 
-    def kname(self):
-        return self.kernel + ("" if "-rt" in self.kernel else self.ktype)
+    def get_full_kernel_name(self):
+        """Returns the kernel name with flavor suffix"""
+        # some kernel versions already have the suffix, some other don't
+        ktype = "" if "-rt" in self.kernel else self.ktype
+        return self.kernel + ktype
 
 
     def base_cs_name(self):
@@ -249,7 +252,7 @@ class Codestream:
         else:
             mod_path = Path("lib")
 
-        return get_datadir(arch)/mod_path/"modules"/self.kname()
+        return get_datadir(arch)/mod_path/"modules"/self.get_full_kernel_name()
 
     # A codestream can be patching multiple objects, so get the path related to
     # the module that we are interested

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -34,7 +34,8 @@ class Codestream:
         self.project = project
         self.patchid = patchid
         self.kernel = kernel
-        self.archs = archs if archs is not None else []
+
+        self.archs = archs if archs is not None else self.__get_default_archs()
         self.files = files if files is not None else {}
         self.modules = modules if modules is not None else {}
         self.configs = configs if configs is not None else {}
@@ -61,7 +62,6 @@ class Codestream:
 
         cs_name = f"{sle}.{sp}{rt}u{update}"
         ret = cls(cs_name, proj, patchid, kernel)
-        ret.set_default_archs()
         return ret
 
 
@@ -141,18 +141,16 @@ class Codestream:
 
         return f"{repo}_Products_SLERT_Update"
 
-    def set_default_archs(self):
+    def __get_default_archs(self):
         # RT is supported only on x86_64 at the moment
         if self.rt:
-            self.archs = ["x86_64"]
-
+            return ["x86_64"]
         # MICRO 6.0 doesn't support ppc64le
         elif self.is_micro:
-            self.archs = ["x86_64", "s390x"]
-
+            return ["x86_64", "s390x"]
         # We support all architecture for all other codestreams
-        else:
-            self.archs = ["x86_64", "s390x", "ppc64le"]
+        return ["x86_64", "s390x", "ppc64le"]
+
 
     def set_files(self, files):
         self.files = files

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -30,7 +30,6 @@ class Codestream:
         self.files = files
         self.modules = modules
         self.configs = configs
-        self.repo = self.get_repo()
 
     @classmethod
     def from_codestream(cls, cs, proj, patchid, kernel):
@@ -86,7 +85,6 @@ class Codestream:
                 "files" : self.files,
                 "modules" : self.modules,
                 "configs" : self.configs,
-                "repo" : self.repo,
                 }
 
     def __eq__(self, cs):

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -15,8 +15,8 @@ class Codestream:
                  "project", "patchid", "kernel", "archs", "files", "modules",
                  "repo", "configs")
 
-    def __init__(self, sle, sp, update, rt, project, patchid, kernel, archs,
-                 files, modules, configs):
+    def __init__(self, sle, sp, update, rt, project="", patchid="", kernel="",
+                 archs=None, files=None, modules=None, configs=None):
         self.sle = sle
         self.sp = sp
         self.update = update
@@ -26,10 +26,10 @@ class Codestream:
         self.project = project
         self.patchid = patchid
         self.kernel = kernel
-        self.archs = archs
-        self.files = files
-        self.modules = modules
-        self.configs = configs
+        self.archs = archs if archs is not None else []
+        self.files = files if files is not None else {}
+        self.modules = modules if modules is not None else {}
+        self.configs = configs if configs is not None else {}
 
     @classmethod
     def from_codestream(cls, cs, proj, patchid, kernel):
@@ -51,7 +51,7 @@ class Codestream:
         else:
             assert False, "codestream name should contain either SLE or MICRO!"
 
-        ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel, [], {}, {}, {})
+        ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel)
         ret.set_archs()
         return ret
 
@@ -62,7 +62,7 @@ class Codestream:
         if not match:
             raise ValueError("Filter regexp error!")
         return cls(int(match.group(1)), int(match.group(2)),
-                   int(match.group(4)), match.group(3), "", "", "", [], {}, {}, {})
+                   int(match.group(4)), match.group(3))
 
 
     @classmethod

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -11,7 +11,7 @@ from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_all_symbols_fro
 from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
 
 class Codestream:
-    __slots__ = ("sle", "sp", "update", "rt", "ktype", "needs_ibt", "is_micro",
+    __slots__ = ("sle", "sp", "update", "rt", "ktype", "is_micro",
                  "project", "patchid", "kernel", "archs", "files", "modules",
                  "repo", "configs")
 
@@ -23,7 +23,6 @@ class Codestream:
         self.rt = rt
         self.ktype = "-rt" if rt else "-default"
         self.is_micro = sle == 6
-        self.needs_ibt = self.is_micro or sle > 15 or (sle == 15 and sp >= 6)
         self.project = project
         self.patchid = patchid
         self.kernel = kernel
@@ -239,6 +238,9 @@ class Codestream:
         product_base_name = self.get_base_product_name()
         return f"{product_base_name}_Update_{self.update}"
 
+
+    def needs_ibt(self):
+        return self.is_micro or self.sle > 15 or (self.sle == 15 and self.sp >= 6)
 
     # 15.4 onwards we don't have module_mutex, so template generates
     # different code

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -73,6 +73,21 @@ class Codestream:
                    data["archs"], data["files"], data["modules"],
                    data["configs"])
 
+    def to_data(self):
+        return {
+                "sle" : self.sle,
+                "sp" : self.sp,
+                "update" : self.update,
+                "rt" : self.rt,
+                "project" : self.project,
+                "patchid": self.patchid,
+                "kernel" : self.kernel,
+                "archs" : self.archs,
+                "files" : self.files,
+                "modules" : self.modules,
+                "configs" : self.configs,
+                "repo" : self.repo,
+                }
 
     def __eq__(self, cs):
         return self.sle == cs.sle and \
@@ -418,18 +433,3 @@ class Codestream:
     def read_file(self, file):
         return read_file_in_tag(self.kernel, file)
 
-    def data(self):
-        return {
-                "sle" : self.sle,
-                "sp" : self.sp,
-                "update" : self.update,
-                "rt" : self.rt,
-                "project" : self.project,
-                "patchid": self.patchid,
-                "kernel" : self.kernel,
-                "archs" : self.archs,
-                "files" : self.files,
-                "modules" : self.modules,
-                "configs" : self.configs,
-                "repo" : self.repo,
-                }

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -52,7 +52,7 @@ class Codestream:
             assert False, "codestream name should contain either SLE or MICRO!"
 
         ret = cls(int(sle), int(sp), int(u), rt, proj, patchid, kernel)
-        ret.set_archs()
+        ret.set_default_archs()
         return ret
 
 
@@ -145,13 +145,13 @@ class Codestream:
 
         return f"{repo}_Products_SLERT_Update"
 
-    def set_archs(self):
+    def set_default_archs(self):
         # RT is supported only on x86_64 at the moment
         if self.rt:
             self.archs = ["x86_64"]
 
-        # MICRO 6.0 doest support ppc64le
-        elif "6.0" in self.full_cs_name():
+        # MICRO 6.0 doesn't support ppc64le
+        elif self.is_micro:
             self.archs = ["x86_64", "s390x"]
 
         # We support all architecture for all other codestreams

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -40,30 +40,6 @@ class Codestream:
         self.modules = modules if modules is not None else {}
         self.configs = configs if configs is not None else {}
 
-    @classmethod
-    def from_codestream(cls, cs, proj, patchid, kernel):
-        # Parse SLE15-SP2_Update_25 to 15.2u25
-        rt = "rt" if "-RT" in cs else ""
-        sp = "0"
-        update = "0"
-
-        # SLE12-SP5_Update_51
-        if "SLE" in cs:
-            sle, _, update = cs.replace("SLE", "").replace("-RT", "").split("_")
-            if "-SP" in sle:
-                sle, sp = sle.split("-SP")
-        # MICRO-6-0_Update_2
-        elif "MICRO" in cs:
-            sle, sp, update = cs.replace("MICRO-", "").replace("-RT", "").replace("_Update_", "-").split("-")
-            if rt and int(update) >= 5:
-                kernel = kernel + "-rt"
-        else:
-            assert False, "codestream name should contain either SLE or MICRO!"
-
-        cs_name = f"{sle}.{sp}{rt}u{update}"
-        ret = cls(cs_name, proj, patchid, kernel)
-        return ret
-
 
     @classmethod
     def from_data(cls, data):

--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -107,14 +107,14 @@ def get_codestream_by_name(name):
     return _codestreams.get(name, None)
 
 
-def get_codestreams_dict():
+def get_codestreams_list():
     """
-    Retrieve the dictionary of all codestreams.
+    Retrieve the list of all codestream.
 
     Returns:
-        dict: A dictionary of all codestreams.
+        list: A list of all codestream.
     """
-    return _codestreams
+    return list(_codestreams.values())
 
 
 def get_codestreams_data(name: str):

--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -61,7 +61,7 @@ def store_codestreams(lp_name, working_cs):
     """
     # Update the latest state of the codestreams
     for cs in working_cs:
-        _codestreams[cs.name()] = cs
+        _codestreams[cs.full_cs_name()] = cs
 
     # Format each codestream for the json
     cs_data = {}

--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -66,7 +66,7 @@ def store_codestreams(lp_name, working_cs):
     # Format each codestream for the json
     cs_data = {}
     for key, cs in _codestreams.items():
-        cs_data[key] = cs.data()
+        cs_data[key] = cs.to_data()
 
     data = {"archs": _cs_data.archs,
             "upstream": _cs_data.upstream,

--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -117,16 +117,6 @@ def get_codestreams_dict():
     return _codestreams
 
 
-def get_codestreams_items():
-    """
-    Retrieve the items (key-value pairs) of the codestreams dictionary.
-
-    Returns:
-        dict_items: The items of the codestreams dictionary.
-    """
-    return _codestreams.items()
-
-
 def get_codestreams_data(name: str):
     """
     Retrieve the codestream data for a given attribute name.

--- a/klpbuild/klplib/codestreams_data.py
+++ b/klpbuild/klplib/codestreams_data.py
@@ -17,12 +17,11 @@ from klpbuild.klplib.config import get_user_path
 class CodestreamData:
     cve: str
     archs: list[str]
-    patched_kernels: list[str]
     patched_cs: list[str]
     upstream: list[str]
 
 
-_cs_data = CodestreamData("", [], [], [], {})
+_cs_data = CodestreamData("", [], [], [])
 _codestreams = {}
 
 
@@ -40,11 +39,9 @@ def load_codestreams(lp_name):
     if cs_file.is_file():
         with open(cs_file) as f:
             jfile = json.loads(f.read(), object_pairs_hook=OrderedDict)
-            _cs_data = CodestreamData(cve=jfile["cve"],
-                                          archs=jfile["archs"],
-                                          patched_kernels=jfile["patched_kernels"],
-                                          patched_cs=jfile["patched_cs"],
-                                          upstream=jfile["upstream"])
+            _cs_data = CodestreamData(cve=jfile["cve"], archs=jfile["archs"],
+                                      patched_cs=jfile["patched_cs"],
+                                      upstream=jfile["upstream"])
 
             json_cs = jfile["codestreams"]
             for cs in natsorted(json_cs.keys()):
@@ -72,7 +69,6 @@ def store_codestreams(lp_name, working_cs):
             "upstream": _cs_data.upstream,
             "cve": _cs_data.cve,
             "patched_cs": _cs_data.patched_cs,
-            "patched_kernels": _cs_data.patched_kernels,
             "codestreams": cs_data}
 
     cs_file = __get_cs_file(lp_name)

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -116,10 +116,10 @@ def get_cs_packages(cs_list, dest):
                     if pkg == "kernel-default":
                         pkg = "kernel-rt"
 
-                if cs.repo != "standard":
-                    pkg = f"{pkg}.{cs.repo}"
+                if cs.get_repo() != "standard":
+                    pkg = f"{pkg}.{cs.get_repo()}"
 
-                ret = osc.build.get_binary_list(cs.project, cs.repo, arch, pkg)
+                ret = osc.build.get_binary_list(cs.project, cs.get_repo(), arch, pkg)
                 for file in re.findall(regex, str(etree.tostring(ret))):
                     # FIXME: adjust the regex to only deal with strings
                     if isinstance(file, str):
@@ -139,7 +139,7 @@ def get_cs_packages(cs_list, dest):
                         if arch != ARCH:
                             continue
 
-                    rpms.append((osc, i, cs, cs.project, cs.repo, arch, pkg, rpm, dest))
+                    rpms.append((osc, i, cs, cs.project, cs.get_repo(), arch, pkg, rpm, dest))
                     i += 1
 
     return rpms

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -30,7 +30,7 @@ def convert_prj_to_cs(prj, prefix):
 
 
 def convert_cs_to_prj(cs, prefix):
-    return prefix + "-" + cs.name().replace(".", "_")
+    return prefix + "-" + cs.full_cs_name().replace(".", "_")
 
 
 def do_work(func, args):
@@ -173,7 +173,7 @@ def validate_livepatch_module(cs, arch, rpm_dir, rpm):
 
     funcs = find_missing_symbols(cs, arch, lp_mod_path)
     if funcs:
-        logging.warning('%s:%s Undefined functions: %s', cs.name(), arch, " ".join(funcs))
+        logging.warning('%s:%s Undefined functions: %s', cs.full_cs_name(), arch, " ".join(funcs))
 
     shutil.rmtree(Path(rpm_dir, "lib"), ignore_errors=True)
 
@@ -183,10 +183,10 @@ def download_binary_rpms(args, total):
 
     try:
         osc.build.download_binary(prj, repo, arch, pkg, rpm, dest)
-        logging.info("(%d/%d) %s %s: ok", i, total, cs.name(), rpm)
+        logging.info("(%d/%d) %s %s: ok", i, total, cs.full_cs_name(), rpm)
     except OSError as e:
         if e.errno == errno.EEXIST:
-            logging.info("(%d/%d) %s %s: already downloaded. skipping", i, total, cs.name(), rpm)
+            logging.info("(%d/%d) %s %s: already downloaded. skipping", i, total, cs.full_cs_name(), rpm)
         else:
             raise RuntimeError(f"download error on {prj}: {rpm}") from e
 
@@ -250,7 +250,7 @@ def extract_rpms(args, total):
     cmd = f"rpm2cpio {rpm_file} | cpio --quiet -uidm"
     subprocess.check_output(cmd, shell=True, stderr=None, cwd=path_dest)
 
-    logging.info("(%d/%d) extracted %s %s: ok", i, total, cs.name(), rpm)
+    logging.info("(%d/%d) extracted %s %s: ok", i, total, cs.full_cs_name(), rpm)
 
 
 def download_cs_rpms(cs_list):
@@ -268,7 +268,7 @@ def download_cs_rpms(cs_list):
         for arch in cs.archs:
             # Extract modules and vmlinux files that are compressed
             mod_path = cs.get_mod_path(arch)
-            logging.info("extracting %s:%s in %s", arch, cs.name(), str(mod_path))
+            logging.info("extracting %s:%s in %s", arch, cs.full_cs_name(), str(mod_path))
             for fext, ecmd in [("zst", "unzstd --rm -f -d"), ("xz", "xz --quiet -d -k")]:
                 cmd = rf'find {mod_path} -name "*.{fext}" -exec {ecmd} --quiet {{}} \;'
                 subprocess.check_output(cmd, shell=True)
@@ -279,7 +279,7 @@ def download_cs_rpms(cs_list):
                 f_path = cs.get_boot_file(f"{f}.gz", arch)
                 # ppc64le doesn't gzips vmlinux
                 if f_path.exists():
-                    logging.info("extracting %s:%s:%s", arch, cs.name(), f)
+                    logging.info("extracting %s:%s:%s", arch, cs.full_cs_name(), f)
                     subprocess.check_output(rf'gzip -k -d -f {f_path}', shell=True)
 
         # Use the SLE .config

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -151,11 +151,6 @@ def get_branch_patches(cve, mbranch):
 
 @__check_kernel_source_tags_are_fetched
 def get_patches(cve, savedir=None):
-    # Support CVEs from 2020 up to 2029
-    if not re.match(r"^202[0-9]-[0-9]{4,7}$", cve):
-        logging.info("Invalid CVE number '%s', skipping the processing of getting the patches.", cve)
-        return {}
-
     logging.info("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 
     # Store all patches from each branch and upstream

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -252,7 +252,7 @@ def get_patched_kernels(codestreams, patches, cve):
     kernels = set()
 
     for cs in codestreams:
-        bc = cs.name().split("u")[0]
+        bc = cs.full_cs_name().split("u")[0]
         suse_patches = patches[bc]
         if not suse_patches:
             continue
@@ -260,7 +260,7 @@ def get_patched_kernels(codestreams, patches, cve):
         # Proceed to analyse each codestream's kernel
         kernel = cs.kernel
 
-        logging.debug(f"\n{cs.name()} ({kernel}):")
+        logging.debug(f"\n{cs.full_cs_name()} ({kernel}):")
         for patch in suse_patches:
             if not ksrc_read_rpm_file(kernel, patch):
                 break
@@ -280,7 +280,7 @@ def cs_is_affected(cs, cve, patches):
     if not cve:
         return True
 
-    return len(patches[cs.name_cs()]) > 0
+    return len(patches[cs.base_cs_name()]) > 0
 
 
 def ksrc_read_rpm_file(kernel_version, file_path):

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -151,16 +151,6 @@ def get_branch_patches(cve, mbranch):
 
 @__check_kernel_source_tags_are_fetched
 def get_patches(cve, savedir=None):
-    kern_src = get_user_path('kernel_src_dir', isopt=True)
-    if not kern_src:
-        logging.info("kernel_src_dir not found, skip getting SUSE commits")
-        return {}
-
-    # ensure that the user informed the commits at least once per 'project'
-    if not cve:
-        logging.info("No CVE informed, skipping the processing of getting the patches.")
-        return {}
-
     # Support CVEs from 2020 up to 2029
     if not re.match(r"^202[0-9]-[0-9]{4,7}$", cve):
         logging.info("Invalid CVE number '%s', skipping the processing of getting the patches.", cve)
@@ -234,17 +224,8 @@ def get_patches(cve, savedir=None):
     return patches
 
 
-def get_patched_kernels(codestreams, patches, cve):
+def get_patched_kernels(codestreams, patches):
     if not patches:
-        return []
-
-    kern_src = get_user_path('kernel_src_dir', isopt=True)
-    if not kern_src:
-        logging.info("kernel_src_dir not found, skip getting SUSE commits")
-        return []
-
-    if not cve:
-        logging.info("No CVE informed, skipping the processing of getting the patched kernels.")
         return []
 
     logging.info("Searching for already patched codestreams...")

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 from pathlib import PurePath
 
-from natsort import natsorted
 from functools import wraps
 
 from klpbuild.klplib import utils

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -29,7 +29,7 @@ def analyse_files(cs_list, sle_patches):
     report = defaultdict(list)
 
     for cs in cs_list:
-            bc = cs.name_cs()
+            bc = cs.base_cs_name()
             patches = sle_patches[bc]
             branch = KERNEL_BRANCHES[bc]
             files = get_patch_files(patches, branch)

--- a/klpbuild/klplib/supported.py
+++ b/klpbuild/klplib/supported.py
@@ -94,7 +94,7 @@ def __download_supported_file():
         list[str]: The list of lines of the supported file, excluding the
         header.
     """
-    logging.info("Downloading codestreams file")
+    logging.debug("Downloading codestreams file")
 
     if SUSE_CERT.exists():
         req = requests.get(SUPPORTED_CS_URL, verify=SUSE_CERT, timeout=15)

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -415,7 +415,7 @@ def __generate_header_file(lp_name, lp_path, cs):
     # We don't need any setups on IBT besides the livepatch_init/cleanup ones
     header_templ = TEMPL_NO_SYMS_H
 
-    if not cs.needs_ibt:
+    if not cs.needs_ibt():
         configs = set()
         config = ""
         has_cleanup = False

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -40,7 +40,7 @@ def classify_codestreams(cs_list):
     cs_group = {}
     for cs in cs_list:
         if not isinstance(cs, str):
-            cs = cs.name()
+            cs = cs.full_cs_name()
 
         prefix, up = cs.split("u")
         if not cs_group.get(prefix, ""):
@@ -230,7 +230,7 @@ def filter_codestreams(lp_filter, cs_list, verbose=False):
     result = []
     filtered = []
     for cs in full_cs:
-        name = cs.name()
+        name = cs.full_cs_name()
 
         if lp_filter and not re.match(lp_filter, name):
             filtered.append(name)

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -219,10 +219,7 @@ def check_module_unsupported(arch, mod_path):
 
 
 def filter_codestreams(lp_filter, cs_list, verbose=False):
-    if isinstance(cs_list, dict):
-        full_cs = copy.deepcopy(list(cs_list.values()))
-    else:
-        full_cs = copy.deepcopy(cs_list)
+    full_cs = copy.deepcopy(cs_list)
 
     if verbose:
         logging.info("Checking filter...")

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -219,26 +219,24 @@ def check_module_unsupported(arch, mod_path):
 
 
 def filter_codestreams(lp_filter, cs_list, verbose=False):
-    full_cs = copy.deepcopy(cs_list)
+    if not lp_filter:
+        return cs_list
 
     if verbose:
         logging.info("Checking filter...")
 
     result = []
     filtered = []
-    for cs in full_cs:
+    for cs in cs_list:
         name = cs.full_cs_name()
-
-        if lp_filter and not re.match(lp_filter, name):
+        if re.match(lp_filter, name):
+            result.append(cs)
+        else:
             filtered.append(name)
-            continue
 
-        result.append(cs)
-
-    if verbose:
-        if filtered:
-            logging.info("Skipping codestreams:")
-            logging.info("\t%s", classify_codestreams_str(filtered))
+    if verbose and filtered:
+        logging.info("Skipping codestreams:")
+        logging.info("\t%s", classify_codestreams_str(filtered))
 
     return result
 

--- a/klpbuild/plugins/cs_diff.py
+++ b/klpbuild/plugins/cs_diff.py
@@ -8,7 +8,7 @@ import logging
 import sys
 
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import get_codestreams_dict
+from klpbuild.klplib.codestreams_data import get_codestreams_list
 from klpbuild.klplib.utils import filter_codestreams
 from klpbuild.plugins.extract import get_cs_code
 
@@ -28,7 +28,7 @@ def cs_diff(lp_name, lp_filter):
     """
     To compare two codestreams the filter should result in exactly two codestreams
     """
-    cs_args = filter_codestreams(lp_filter, get_codestreams_dict(), verbose=True)
+    cs_args = filter_codestreams(lp_filter, get_codestreams_list(), verbose=True)
     if len(cs_args) != 2:
         logging.error("The filter specified found %d while it should point to only 2.", len(cs_args))
         sys.exit(1)

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -468,7 +468,7 @@ def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
     # Needed, otherwise threads would interfere with each other
     env = os.environ.copy()
 
-    env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt else "0"
+    env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt() else "0"
     env["KCP_MOD_SYMVERS"] = str(cs.get_boot_file("symvers"))
     env["KCP_KBUILD_ODIR"] = str(cs.get_obj_dir())
     env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.ARCH)/cs.get_mod(fdata["module"]))
@@ -558,7 +558,7 @@ def process(lp_name, total, args, avoid_ext):
     args, lenv = cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext)
 
     # Detect and set ibt information. It will be used in the TemplateGen
-    if '-fcf-protection' in cmd or cs.needs_ibt:
+    if '-fcf-protection' in cmd or cs.needs_ibt():
         cs.files[fname]["ibt"] = True
 
     out_log = Path(out_dir, "ccp.out.txt")

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -22,7 +22,7 @@ from natsort import natsorted
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_dict
+from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_list
 from klpbuild.klplib.config import get_user_settings
 from klpbuild.klplib.templ import generate_livepatches
 
@@ -621,7 +621,7 @@ def start_extract(lp_name, lp_filter, apply_patches, avoid_ext):
         with open(quilt_log_path(lp_name, apply_patches), "w") as f:
             f.truncate()
 
-    working_cs = utils.filter_codestreams(lp_filter, get_codestreams_dict(), verbose=True)
+    working_cs = utils.filter_codestreams(lp_filter, get_codestreams_list(), verbose=True)
 
     if len(working_cs) == 0:
         logging.error("No codestreams found")

--- a/klpbuild/plugins/log.py
+++ b/klpbuild/plugins/log.py
@@ -34,7 +34,7 @@ def log(lp_name, lp_filter, arch):
         sys.exit(1)
 
     if len(cs_list) > 1:
-        cs_names = [cs.name() for cs in cs_list]
+        cs_names = [cs.full_cs_name() for cs in cs_list]
         logging.error("Filter '%s' returned %d entries (%s), while expecting just one. Aborting. ",
                       lp_filter, len(cs_list), " ".join(cs_names))
         sys.exit(1)

--- a/klpbuild/plugins/log.py
+++ b/klpbuild/plugins/log.py
@@ -9,7 +9,7 @@ import sys
 from osctiny import Osc
 
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import get_codestreams_dict
+from klpbuild.klplib.codestreams_data import get_codestreams_list
 from klpbuild.klplib.ibs import convert_cs_to_prj, prj_prefix
 from klpbuild.klplib.utils import ARCHS, filter_codestreams
 
@@ -27,7 +27,7 @@ def register_argparser(subparser):
 
 
 def log(lp_name, lp_filter, arch):
-    cs_list = filter_codestreams(lp_filter, get_codestreams_dict())
+    cs_list = filter_codestreams(lp_filter, get_codestreams_list())
 
     if not cs_list:
         logging.error("log: No codestreams found for filter %s", lp_filter)

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -106,13 +106,13 @@ def prepare_tests(lp_name, lp_filter):
 
             rpm_dir = Path(cs.get_ccp_dir(lp_name), arch, "rpm")
             if not rpm_dir.exists():
-                logging.info("%s/%s: rpm dir not found. Skipping.", cs.name(), arch)
+                logging.info("%s/%s: rpm dir not found. Skipping.", cs.full_cs_name(), arch)
                 continue
 
             # TODO: there will be only one rpm, format it directly
             rpm = os.listdir(rpm_dir)
             if len(rpm) > 1:
-                raise RuntimeError(f"ERROR: {cs.name()}/{arch}. {len(rpm)} rpms found. Excepting to find only one")
+                raise RuntimeError(f"ERROR: {cs.full_cs_name()}/{arch}. {len(rpm)} rpms found. Excepting to find only one")
 
             for rpm in os.listdir(rpm_dir):
                 # Check for dependencies

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -15,7 +15,7 @@ from natsort import natsorted
 from osctiny import Osc
 
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import get_codestream_by_name, get_codestreams_dict
+from klpbuild.klplib.codestreams_data import get_codestream_by_name, get_codestreams_list
 from klpbuild.klplib.ibs import convert_prj_to_cs, delete_built_rpms, delete_project, do_work, download_binary_rpms, get_projects, prj_prefix, validate_livepatch_module
 from klpbuild.klplib.utils import ARCHS, filter_codestreams, get_tests_path, get_workdir
 
@@ -100,7 +100,7 @@ def prepare_tests(lp_name, lp_filter):
 
         logging.info("Checking %s symbols...", arch)
         build_cs = []
-        for cs in filter_codestreams(lp_filter, get_codestreams_dict()):
+        for cs in filter_codestreams(lp_filter, get_codestreams_list()):
             if arch not in cs.archs:
                 continue
 

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -123,7 +123,7 @@ def prepare_tests(lp_name, lp_filter):
             if cs.rt and arch != "x86_64":
                 continue
 
-            build_cs.append(cs.name_full())
+            build_cs.append(cs.get_full_product_name())
 
         logging.info("Done.")
 

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -40,7 +40,7 @@ def create_prj_meta(cs):
                "<publish><disable/></publish>" + \
                "<debuginfo><disable/></debuginfo>" + \
                "<repository name=\"standard\">" + \
-               f"<path project=\"{cs.project}\" repository=\"{cs.repo}\"/>" + \
+               f"<path project=\"{cs.project}\" repository=\"{cs.get_repo()}\"/>" + \
                "".join([f"<arch>{arch}</arch>" for arch in cs.archs]) + \
                "</repository>" + \
            "</project>"

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -50,7 +50,7 @@ def create_lp_package(osc, lp_name, i, total, cs):
     kgr_path = get_user_path('kgr_patches_dir')
     branch = get_cs_branch(cs, lp_name, kgr_path)
     if not branch:
-        logging.info("Could not find git branch for %s. Skipping.", cs.name())
+        logging.info("Could not find git branch for %s. Skipping.", cs.full_cs_name())
         return
 
     # If the project exists, drop it first
@@ -58,7 +58,7 @@ def create_lp_package(osc, lp_name, i, total, cs):
     delete_project(osc, 0, 0, prj, verbose=False)
 
     meta = create_prj_meta(cs)
-    prj_desc = f"Development of livepatches for {cs.name()}"
+    prj_desc = f"Development of livepatches for {cs.full_cs_name()}"
 
     try:
         osc.projects.set_meta(
@@ -82,10 +82,10 @@ def create_lp_package(osc, lp_name, i, total, cs):
 
     osc.packages.checkout(prj, "klp", prj_path)
 
-    base_branch = get_kgraft_branch(cs.name())
+    base_branch = get_kgraft_branch(cs.full_cs_name())
 
     logging.info("(%s/%s) pushing %s using branches %s/%s...",
-                 i, total, cs.name(), str(base_branch), str(branch))
+                 i, total, cs.full_cs_name(), str(base_branch), str(branch))
 
     # Clone the repo and checkout to the codestream branch. The branch should be based on master to avoid rebasing
     # conflicts
@@ -137,7 +137,7 @@ def create_lp_package(osc, lp_name, i, total, cs):
     osc.packages.cmd(prj, "klp", "commit", comment=f"Dump {branch}")
     shutil.rmtree(prj_path)
 
-    logging.info("(%d/%d) %s done", i, total, cs.name())
+    logging.info("(%d/%d) %s done", i, total, cs.full_cs_name())
 
 
 def push(lp_name, lp_filter, wait=False):

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -14,7 +14,7 @@ import time
 from osctiny import Osc
 
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import get_codestreams_dict
+from klpbuild.klplib.codestreams_data import get_codestreams_list
 from klpbuild.klplib.config import get_user_path
 from klpbuild.klplib.ibs import convert_cs_to_prj, delete_project, prj_prefix
 from klpbuild.klplib.utils import classify_codestreams_str, filter_codestreams, get_cs_branch, get_kgraft_branch
@@ -141,7 +141,7 @@ def create_lp_package(osc, lp_name, i, total, cs):
 
 
 def push(lp_name, lp_filter, wait=False):
-    cs_list = filter_codestreams(lp_filter, get_codestreams_dict())
+    cs_list = filter_codestreams(lp_filter, get_codestreams_list())
 
     if not cs_list:
         logging.error("push: No codestreams found for %s", lp_name)

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -119,7 +119,7 @@ def create_lp_package(osc, lp_name, i, total, cs):
 
     # Fix RELEASE version
     with open(Path(code_path, "scripts", "release-version.sh"), "w") as f:
-        ver = cs.name_full().replace("EMBARGO", "")
+        ver = cs.get_full_product_name().replace("EMBARGO", "")
         f.write(f"RELEASE={ver}")
 
     subprocess.check_output(

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -68,7 +68,7 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
         for cs in utils.filter_codestreams(lp_filter, all_codestreams, verbose=True):
 
             if cs.kernel in patched_kernels:
-                patched_cs.append(cs.name())
+                patched_cs.append(cs.full_cs_name())
                 continue
 
             if not cs_is_affected(cs, cve, patches):

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -61,7 +61,7 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
     else:
         assert cve
         patches = get_patches(cve, savedir)
-        patched_kernels = get_patched_kernels(all_codestreams, patches, cve)
+        patched_kernels = get_patched_kernels(all_codestreams, patches)
 
         upstream = patches.get("upstream")
 

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -47,12 +47,13 @@ def scan(cve, conf, lp_filter, download, savedir=None):
     upstream = patches.get("upstream", [])
 
     all_codestreams = get_supported_codestreams()
-    patched_kernels = get_patched_kernels(all_codestreams, patches)
+    filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)
+    patched_kernels = get_patched_kernels(filtered_codesteams, patches)
 
     working_cs = []
     patched_cs = []
     unaffected_cs = []
-    for cs in utils.filter_codestreams(lp_filter, all_codestreams, verbose=True):
+    for cs in filtered_codesteams:
 
         if cs.kernel in patched_kernels:
             patched_cs.append(cs.full_cs_name())
@@ -87,6 +88,7 @@ def scan(cve, conf, lp_filter, download, savedir=None):
         kmodules_report = patch.analyse_kmodules(working_cs)
         patch.print_kmodules(kmodules_report)
         unsupported = patch.filter_unsupported_kmodules(working_cs)
+
     # If conf is set, drop codestream not containing that conf entry from working_cs
     elif conf:
         tmp_working_cs = []

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -4,6 +4,7 @@
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com
 
 import logging
+import re
 import sys
 
 from klpbuild.klplib import utils
@@ -59,7 +60,9 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
         patches = {}
         patched_kernels = []
     else:
-        assert cve
+        # Support CVEs from 2020 up to 2029
+        assert cve and re.match(r"^202[0-9]-[0-9]{4,7}$", cve)
+
         patches = get_patches(cve, savedir)
         patched_kernels = get_patched_kernels(all_codestreams, patches)
 

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -136,4 +136,4 @@ def scan(cve, conf, no_check, lp_filter, download, savedir=None):
     logging.info("All affected codestreams:")
     logging.info("\t%s", utils.classify_codestreams_str(working_cs))
 
-    return upstream, patched_cs, patched_kernels, working_cs
+    return upstream, patched_cs, working_cs

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -82,10 +82,6 @@ def setup(lp_name, lp_filter, no_check, archs, cve, conf, module, file_funcs,
           mod_file_funcs, conf_mod_file_funcs):
     assert isinstance(archs, list)
 
-    lp_path = utils.get_workdir(lp_name)
-    if lp_path.exists() and not lp_path.is_dir():
-        raise ValueError("--name needs to be a directory, or not to exist")
-
     ffuncs = setup_file_funcs(conf, module, file_funcs,
                                     mod_file_funcs, conf_mod_file_funcs)
 

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -10,6 +10,7 @@ from natsort import natsorted
 from klpbuild.klplib import utils
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
 from klpbuild.klplib.codestreams_data import get_codestreams_data, set_codestreams_data, store_codestreams
+from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.templ import generate_commit_msg_file
 
 from klpbuild.plugins.scan import scan
@@ -130,10 +131,16 @@ def setup_codestreams(lp_name, data):
 
     # Called at this point because codestreams is populated
     # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-    upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
-                                             data["no_check"],
-                                             data["lp_filter"], True,
-                                             utils.get_workdir(lp_name))
+    if data["no_check"]:
+        logging.info("Option --no-check was specified, checking all codestreams that are not filtered out...")
+        upstream = []
+        patched_cs = []
+        all_codestreams = get_supported_codestreams()
+        codestreams = utils.filter_codestreams(data["lp_filter"], all_codestreams)
+    else:
+        upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
+                                                 data["lp_filter"], True,
+                                                 utils.get_workdir(lp_name))
 
     # Add new codestreams to the already existing list, skipping duplicates
     old_patched_cs = get_codestreams_data('patched_cs')

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -192,7 +192,7 @@ def setup_project_files(lp_name, codestreams, ffuncs, archs):
 
             # Validate if the module being livepatched is supported or not
             if utils.check_module_unsupported(utils.ARCH, mod_path):
-                logging.warning("%s (%s}): Module %s is not supported by SLE", cs.full_cs_name(), cs.kernel, mod)
+                logging.warning("%s (%s): Module %s is not supported by SLE", cs.full_cs_name(), cs.kernel, mod)
 
             cs.modules[mod] = str(mod_path)
             mod_syms.setdefault(mod, [])

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -170,12 +170,12 @@ def setup_project_files(lp_name, codestreams, ffuncs, archs):
             cs.validate_config(archs, fdata["conf"], mod)
 
             if not cs.check_file_exists(f):
-                raise RuntimeError(f"{cs.name()} ({cs.kernel}): File {f} not found.")
+                raise RuntimeError(f"{cs.full_cs_name()} ({cs.kernel}): File {f} not found.")
 
             ipa_f = cs.get_ipa_file(f)
             if not ipa_f.is_file():
                 ipa_f.touch()
-                logging.warning("%s (%s): File %s not found. Creating an empty file.", cs.name(), cs.kernel, ipa_f)
+                logging.warning("%s (%s): File %s not found. Creating an empty file.", cs.full_cs_name(), cs.kernel, ipa_f)
 
             # If the config was enabled on all supported architectures,
             # there is no point in leaving the conf being set, since the
@@ -187,7 +187,7 @@ def setup_project_files(lp_name, codestreams, ffuncs, archs):
 
             # Validate if the module being livepatched is supported or not
             if utils.check_module_unsupported(utils.ARCH, mod_path):
-                logging.warning("%s (%s}): Module %s is not supported by SLE", cs.name(), cs.kernel, mod)
+                logging.warning("%s (%s}): Module %s is not supported by SLE", cs.full_cs_name(), cs.kernel, mod)
 
             cs.modules[mod] = str(mod_path)
             mod_syms.setdefault(mod, [])
@@ -199,7 +199,7 @@ def setup_project_files(lp_name, codestreams, ffuncs, archs):
             if arch_syms:
                 for arch, syms in arch_syms.items():
                     logging.warning("%s-%s (%s): Symbols %s not found on %s object",
-                                    cs.name(), arch, cs.kernel, ",".join(syms), mod)
+                                    cs.full_cs_name(), arch, cs.kernel, ",".join(syms), mod)
 
     store_codestreams(lp_name, codestreams)
     logging.info("Done. Setup finished.")

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -130,19 +130,17 @@ def setup_codestreams(lp_name, data):
 
     # Called at this point because codestreams is populated
     # FIXME: we should check all configs, like when using --conf-mod-file-funcs
-    upstream, patched_cs, patched_kernels, codestreams = scan(data["cve"],
-                                                             data["conf"],
-                                                             data["no_check"],
-                                                             data["lp_filter"],
-                                                             True,
-                                                             utils.get_workdir(lp_name))
+    upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
+                                             data["no_check"],
+                                             data["lp_filter"], True,
+                                             utils.get_workdir(lp_name))
+
     # Add new codestreams to the already existing list, skipping duplicates
     old_patched_cs = get_codestreams_data('patched_cs')
     new_patched_cs = natsorted(list(set(old_patched_cs + patched_cs)))
 
-    set_codestreams_data(upstream=upstream,
-                         patched_kernels=list(patched_kernels),
-                         patched_cs=new_patched_cs, cve=data['cve'])
+    set_codestreams_data(upstream=upstream, patched_cs=new_patched_cs,
+                         cve=data['cve'])
     return codestreams
 
 

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -9,9 +9,9 @@ from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.utils import ARCHS
 
 
-def test_wrong_cs_filter():
-    with pytest.raises(ValueError, match=r"Filter regexp error!"):
-        Codestream.from_cs("wrong-filter")
+def test_wrong_cs_name():
+    with pytest.raises(ValueError, match=r"Name format error"):
+        Codestream("wrong-filter")
 
 
 def test_find_obj_path_arch():
@@ -19,10 +19,7 @@ def test_find_obj_path_arch():
     Ensure the returned obj path doesn't contain any architecture info
     """
     cs = Codestream.from_data({
-        "sle": 15,
-        "sp": 5,
-        "update": 15,
-        "rt": "",
+        "name": "15.5u15",
         "project": "SUSE:Maintenance:34200",
         "patchid": "",
         "kernel": "5.14.21-150500.55.68",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,13 +8,6 @@ from klpbuild.klplib.utils import filter_codestreams
 
 
 def test_filter():
-    def list_to_dict(cs_list):
-        ret = {}
-
-        for cs in cs_list:
-            ret[cs] = Codestream(cs)
-
-        return ret
 
     def list_to_cs(cs_list):
         ret = []
@@ -25,28 +18,24 @@ def test_filter():
         return ret
 
     # Same output because filter and skip were not informed
-    assert filter_codestreams("", list_to_dict(["12.5u10", "15.6u10"])) \
-        == list_to_cs(["12.5u10", "15.6u10"])
-
-    # Same as before, but using a list instead of a dict
     assert filter_codestreams("", list_to_cs(["12.5u10", "15.6u10"])) \
         == list_to_cs(["12.5u10", "15.6u10"])
 
     # Filter only one codestream
-    assert filter_codestreams("12.5u10", list_to_dict(["12.5u10", "12.5u11", "15.6u10"])) == \
+    assert filter_codestreams("12.5u10", list_to_cs(["12.5u10", "12.5u11", "15.6u10"])) == \
         list_to_cs(["12.5u10"])
 
     # Filter codestreams using regex
-    assert filter_codestreams("12.5u1[01]", list_to_dict(["12.5u10", "12.5u11", "15.6u10"])) \
+    assert filter_codestreams("12.5u1[01]", list_to_cs(["12.5u10", "12.5u11", "15.6u10"])) \
         == list_to_cs(["12.5u10", "12.5u11"])
 
-    assert filter_codestreams("12.5u1[01]|15.6u10", list_to_dict(["12.5u10", "12.5u11", "15.6u10"])) \
+    assert filter_codestreams("12.5u1[01]|15.6u10", list_to_cs(["12.5u10", "12.5u11", "15.6u10"])) \
         == list_to_cs(["12.5u10", "12.5u11", "15.6u10"])
 
     # Use negative filter to skip 15.6u10 codestreams while keeping the 12.5 ones
-    assert filter_codestreams("^(?!15.6u10).*", list_to_dict(["12.5u10", "12.5u11", "15.6u10"])) \
+    assert filter_codestreams("^(?!15.6u10).*", list_to_cs(["12.5u10", "12.5u11", "15.6u10"])) \
         == list_to_cs(["12.5u10", "12.5u11"])
 
     # Use negative filter to skip all 15.6 codestreams while keeping the 12.5 ones
-    assert filter_codestreams("^(?!15.6).*", list_to_dict(["12.5u10", "12.5u11", "15.6u12", "15.6u13"])) \
+    assert filter_codestreams("^(?!15.6).*", list_to_cs(["12.5u10", "12.5u11", "15.6u12", "15.6u13"])) \
         == list_to_cs(["12.5u10", "12.5u11"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ def test_filter():
         ret = {}
 
         for cs in cs_list:
-            ret[cs] = Codestream.from_cs(cs)
+            ret[cs] = Codestream(cs)
 
         return ret
 
@@ -20,7 +20,7 @@ def test_filter():
         ret = []
 
         for cs in cs_list:
-            ret.append(Codestream.from_cs(cs))
+            ret.append(Codestream(cs))
 
         return ret
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,19 +6,19 @@ def test_group_classify():
     assert utils.classify_codestreams(["15.2u10", "15.2u11", "15.3u10", "15.3u12"]) == \
                                         ["15.2u10-11", "15.3u10-12"]
 
-    assert utils.classify_codestreams([Codestream.from_cs("15.2u10"),
-                                       Codestream.from_cs("15.2u11"),
-                                       Codestream.from_cs("15.3u10"),
-                                       Codestream.from_cs("15.3u12")]) == \
+    assert utils.classify_codestreams([Codestream("15.2u10"),
+                                       Codestream("15.2u11"),
+                                       Codestream("15.3u10"),
+                                       Codestream("15.3u12")]) == \
         ["15.2u10-11", "15.3u10-12"]
 
-    assert utils.classify_codestreams([Codestream.from_cs("15.5u11"),
-                                       Codestream.from_cs("15.5u14"),
-                                       Codestream.from_cs("15.6u0"),
-                                       Codestream.from_cs("15.5u6"),
-                                       Codestream.from_cs("15.5u8"),
-                                       Codestream.from_cs("15.5u9"),
-                                       Codestream.from_cs("15.6u10"),
-                                       Codestream.from_cs("15.4u24"),
-                                       Codestream.from_cs("15.4u26")]) == \
+    assert utils.classify_codestreams([Codestream("15.5u11"),
+                                       Codestream("15.5u14"),
+                                       Codestream("15.6u0"),
+                                       Codestream("15.5u6"),
+                                       Codestream("15.5u8"),
+                                       Codestream("15.5u9"),
+                                       Codestream("15.6u10"),
+                                       Codestream("15.4u24"),
+                                       Codestream("15.4u26")]) == \
         ["15.4u24-26", "15.5u6-9", "15.5u11-14", "15.6u0-10"]


### PR DESCRIPTION
This pull request was to refactor the `Codestream` class, but as a side effect I also cleaned other portions of the code.

There are no logical changes, it's mostly about dropping unneeded fields in favor of methods.

I modified the constructor of the `Codestream` class so that we can avoid dealing with random string like `"12.5rtu4"` but rather use the appropriate class with its functions, like:

```py
cs = Codestream("12.5rtu4")
cs.get_config_content()
```

Also, I dropped `no_check` from `scan` as it was anyway not used and it didn't make sense to have it.

I am opening this PR as Draft as I haven't yet fully reviewed it and still depends on #140 .