### PR TITLE
Bugzilla integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ To install the project and dependencies use:
 
 `pipx install .`
 
-To run the project locally and test your changes use:
-
-`./klp-build`
-
 To run tests use:
 
 `tox -e tests`

--- a/klp-build.1
+++ b/klp-build.1
@@ -59,19 +59,74 @@ Re-download also codestream that are not missing.
 .B scan
 In the scan,
 .B klp-build
-does a shallow analysis of the given CVE, searching for already patched codestreams
-and reporting those that most likley are still affected by the bug.
-This subcommand does not store any data, as it is mainly targeted for automation
-and not for livepatch development. For the latter see the
-.B setup
-subcommand.
+does a bulk analysis of all the pending CVEs meant to be livepatched, as
+indicated in SUSE's Bugzilla. Once completed, a full report is generated
+and printed in stdout with all the bugs information. Example report:
+.TP
+.PP
+.EX
+     ID  CVE         SUBSYSTEM       CVSS    PRIORITY      CLASSIFICATION    STATUS         AFFECTED
+-------  ----------  ------------  ------   ----------   ----------------  -------------  --------------------
+122xxxx  2021-xxxxx  scsi             7.8    Medium         complex          Incomplete(0)  No
+122xxxx  2024-xxxxx  drm/amdgpu       7.8    Medium         trivial          Fixed(3)       15.6rtu0 15.6u0
+122xxxx  2024-xxxxx  iommu/vt-d       7.8    High           None             Fixed(1)       15.6rtu0 15.6u0-1
+.EE
+.PP
 .RS 7
+Most of the fields are self-explanatory except for perhaps
+the
+.B status
+and
+.B affected
+ones.
+.TP
+.B status:
+*
+.I Fixed(n)
+Bug has been fixed in all the vulnerable SLEs.
+.sp
+*
+.I Incomplete(n)
+Most likely someone is working on the bug.
+.sp
+*
+.I Not-Fixed
+No one has started working on the bug yet. Or the bug has been discarded,
+but it cannot be confirmed by
+.B klp-build
+alone.
+.sp
+*
+.I Dropped
+Bug has been discarded with 100% certainty, so no livepatch needed.
+.sp
+.I n
+is the total number of backports for this specific CVE.
+.sp
+.B status
+is derived from the available information in bugzilla, and as such
+it might be incorrect and should be manually verified. That being said, in most cases
+the reported information is realiable enough to be used as a hint.
+.LP
+.B affected:
+List of codestreams still affected by the bug that need to be livepatched.
+.I No
+otherwise.
+.PP
+This subcommand does not store any data, as it is mainly targeted for automation
+and as a first step during livepatch development.
+.PP
+Optional arguments:
 .TP
 .BI --cve " CVE"
-The CVE to be analyzed.
+If passed, scan will just analyse the given CVE.
 .TP
 .B --download
 Download missing codestreams data.
+.TP
+.BI --conf " CONF"
+Helps to check only the codestreams that have this config set.
+Not compatible with the automated patch analysis phase.
 .RE
 .TP
 .B setup

--- a/klpbuild/klplib/bugzilla.py
+++ b/klpbuild/klplib/bugzilla.py
@@ -5,26 +5,199 @@
 #          Marcos Paulo de Souza <mpdesouza@suse.com>
 
 import bugzilla
+import time
+from functools import wraps
+
 from klpbuild.klplib.config import get_user_settings
 
+__bzapi = None
+def __check_is_connected(func):
+    """
+    This decorator checks whether there's an active connection to a bugzilla
+    instance. If not, it will attempt to connect to the specified server.
 
-def get_bug_data(bsc):
+    Args:
+        func (function): The function to be wrapped.
+
+    Returns:
+        function: The wrapped function.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        global __bzapi
+        if not __bzapi:
+            __bzapi = __connect_to_bugzilla()
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def __connect_to_bugzilla():
     bz_key = get_user_settings("bugzilla_api_key", True)
     if 'changeit' in bz_key:
         raise RuntimeError("Change the bugzilla_api_key to a valid key.")
 
-    bzapi = bugzilla.Bugzilla("https://bugzilla.suse.com", api_key=bz_key)
-
-    return bzapi.getbug(bsc)
+    return bugzilla.Bugzilla("https://bugzilla.suse.com", api_key=bz_key)
 
 
-def get_bug_title(bsc):
+# Internal list of all pending bugs' dependencies.
+__dep_bugs = []
+
+@__check_is_connected
+def get_pending_bugs():
     """
-    The bug description usually is after the "kernel live patch" message. Return a fixes message
-    if the livepatch name is not an ID from a bug on bugzilla.
+    Return the lists of pending bugs and create an internal list of the corresponding
+    parent bugs (aka dependencies).
+    "Pending bugs" are those tickets that are "open" and assigned to "kernel-lp" user.
     """
-    if not bsc.isnumeric():
+    global __dep_bugs
+
+    query = __bzapi.build_query(
+            status=["NEW","REOPENED","IN_PROGRESS"],
+            component="Kernel Live Patches",
+            assigned_to="kernel-lp")
+
+    query["ids_only"] = True
+    ids = [b.id for b in __bzapi.query(query)]
+    bugs = __bzapi.getbugs(ids)
+
+    deps_ids = [b.depends_on[0] for b in bugs if len(b.depends_on) > 0]
+    deps_fields = ["status", "resolution", "assigned_to", "whiteboard"]
+    __dep_bugs = {d.id:d for d in __bzapi.getbugs(deps_ids,include_fields=deps_fields)}
+
+    return bugs
+
+
+@__check_is_connected
+def get_bug(bsc):
+    """
+    Fetch a bug's data indicated by the given bug id.
+
+    Args:
+        bsc (str/int): bug id. Must be a numerical value.
+
+    Returns:
+        bug object.
+    """
+    if isinstance(bsc, str) and not bsc.isnumeric():
+        return None
+
+    return __bzapi.getbug(bsc)
+
+
+def get_bug_comments(bug):
+    """
+    Return the bug's comments section.
+    """
+    i = 0
+
+    while i < 5:
+        try:
+            return bug.getcomments()
+        except:
+           # There's a max number of allowed simultaneous requests...
+            time.sleep(5)
+            i += 1
+
+    return []
+
+
+def get_bug_classification(bug):
+    """
+    Return the difficulty score assigned by Nicolai in the comment section.
+    """
+    rating = ["trivial", "medium", "complex"]
+
+    for c in get_bug_comments(bug):
+        if "nstange" in c["creator"]:
+            return w if any((w:=i) in c["text"] for i in rating) else "unknown"
+
+    return "None"
+
+
+def get_bug_dep(bug):
+    """
+    Return the corresponding dependency for the given bug.
+    To speed up the lookup it first checks and internal
+    precalculated list of all the dependencies for all bugs.
+    If that fails, it fetches the dependency from bugzilla.
+    """
+    global __dep_bugs
+
+    # XXX: Support returning more than one dependency?
+
+    d = bug.depends_on
+    if not d:
+        return None
+
+    if __dep_bugs and d[0] in __dep_bugs:
+        return __dep_bugs[d[0]]
+
+    return get_bug(d[0])
+
+
+def get_bug_cvss(bug):
+    if bug is None:
+        return "None"
+
+    raw = bug.whiteboard.split(':')
+    return raw[3] if len(raw) >= 4 else "None"
+
+
+def get_bug_summary(bug):
+    return bug.summary.split(':')
+
+
+def get_bug_cve(bug):
+    summary = get_bug_summary(bug)
+    if len(summary) < 2:
+        return ""
+
+    return summary[1][5:].strip()
+
+
+def get_bug_subsys(bug):
+    summary = get_bug_summary(bug)
+    if len(summary) < 3:
+        return "Unknown"
+
+    return summary[3][:40].strip()
+
+
+def get_bug_prio(bug):
+    return bug.priority[5:]
+
+
+def is_bug_dropped(bug):
+    return bug.resolution and bug.resolution in {"INVALID", "WONTFIX", "DUPLICATED"}
+
+
+def get_bug_data(bug):
+    dep = get_bug_dep(bug)
+    return (get_bug_cve(bug), get_bug_subsys(bug), get_bug_cvss(dep),
+            get_bug_classification(bug), get_bug_prio(bug))
+
+
+def get_bug_desc(bug):
+    """
+    The bug description is usually located in the bug's first comment.
+    Return back the whole description if found.
+    """
+    comments = get_bug_comments(bug)
+
+    if not comments:
+        return []
+
+    return comments[0]['text']
+
+
+def get_bug_title(bug):
+    """
+    The bug title usually is after the "kernel live patch" message. Return
+    a fixed message if the bug is not valid.
+    """
+
+    if not bug:
         return "Change me!"
 
-    data = str(get_bug_data(int(bsc)).summary)
+    data = str(bug.summary)
     return data.split("kernel live patch: ")[1].strip()

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -291,6 +291,10 @@ def ksrc_is_module_supported(module, kernel):
         "-!optional"
     }
 
+    SUPPORTED_MARKERS = {
+        "+base",
+    }
+
     mpath = module
     prev = ""
     idx = 1
@@ -306,7 +310,7 @@ def ksrc_is_module_supported(module, kernel):
     #   my/kernel/*
     #   my/*
     while mpath != prev:
-        r = re.compile(rf"^([-+]!?\w*)?\s+{mpath}")
+        r = re.compile(rf"^([-+]!?\w*)?\s+{mpath}(?:\s+#.*)?$")
         matches = [m for line in out if (m := r.match(line))]
 
         # Try more generic path if we don't match
@@ -319,7 +323,7 @@ def ksrc_is_module_supported(module, kernel):
         # At this point we've surely matched. Check if we support it or not.
         markers = [marker for match in matches if (marker := match.group(1))]
         if len(markers) > 1:
-            raise RuntimeError(f"ERROR: matched more than one line in {kernel}:supported.conf")
+            raise RuntimeError(f"ERROR: {mpath} matched more than one line in {kernel}:supported.conf")
 
         # Line has matched but there's no marker -> module is supported
         if not markers:
@@ -329,6 +333,9 @@ def ksrc_is_module_supported(module, kernel):
         if markers[0] in UNSUPPORTED_MARKERS:
             return False
 
-        raise RuntimeError(f"ERROR: marker {marker} in {kernel}:supported.conf is not known!")
+        if markers[0] in SUPPORTED_MARKERS:
+            return True
+
+        raise RuntimeError(f"ERROR: {mpatch} marker {marker} in {kernel}:supported.conf is not known!")
 
     return True

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -156,9 +156,8 @@ def get_branch_patches(cve, mbranch):
 def get_patches(cve, savedir=None):
     logging.info("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 
-    # Store all patches from each branch and upstream
+    # Store all patches from each branch
     patches = {}
-    patches["upstream"] = []
     # Temporal list of upstream commits
     upstream = set()
 
@@ -195,14 +194,11 @@ def get_patches(cve, savedir=None):
             if m:
                 c = m.group(1)[:12]
                 d, msg = get_commit_data(c, upstream_patches_dir)
-                upstream.add((d, c, msg))
+                upstream.add((d, c, msg, f'{c} ("{msg}")'))
 
             patches[bc].append(patch)
 
     for key, bc_patches in patches.items():
-        if key == "upstream":
-            continue
-
         logging.info(f"{key}: {KERNEL_BRANCHES[key]}")
 
         if not bc_patches:
@@ -217,7 +213,7 @@ def get_patches(cve, savedir=None):
 
     logging.info("")
 
-    return patches
+    return upslogs, patches
 
 
 def get_patched_kernels(codestreams, patches):

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from mako.lookup import TemplateLookup
 from mako.template import Template
 
-from klpbuild.klplib.bugzilla import get_bug_title
+from klpbuild.klplib.bugzilla import get_bug_title, get_bug
 from klpbuild.klplib.codestreams_data import get_codestreams_data
 from klpbuild.klplib.utils import ARCHS, fix_mod_string, get_mail, get_workdir, get_lp_number, get_fname
 
@@ -572,7 +572,7 @@ def generate_commit_msg_file(lp_name):
         "cve": cve,
         "commits": cmts,
         "msg": "Upstream commits" if len(cmts) > 1 else "Upstream commit",
-        "title": get_bug_title(get_lp_number(lp_name)),
+        "title": get_bug_title(get_bug(get_lp_number(lp_name))),
     }
     with open(get_workdir(lp_name)/"commit.msg", "w") as f:
         f.write(Template(TEMPL_COMMIT).render(**render_vars))

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -6,12 +6,15 @@
 import logging
 import re
 import sys
+import concurrent.futures
+import tabulate
 
 from klpbuild.klplib import utils
 from klpbuild.klplib import patch
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.data import download_missing_cs_data
 from klpbuild.klplib.ksrc import get_patches, get_patched_kernels, cs_is_affected
+from klpbuild.klplib.bugzilla import get_pending_bugs, get_bug_data, is_bug_dropped, get_bug_dep
 
 PLUGIN_CMD = "scan"
 
@@ -19,7 +22,7 @@ def register_argparser(subparser):
     scan = subparser.add_parser(PLUGIN_CMD)
     scan.add_argument(
         "--cve",
-        required=True,
+        required=False,
         help="Shows which codestreams are vulnerable to the CVE"
     )
     scan.add_argument(
@@ -34,9 +37,67 @@ def register_argparser(subparser):
         help="SLE specific. Download missing codestreams data"
     )
 
-
 def run(cve, conf, lp_filter, download):
+    if not cve:
+        scan_bugzilla()
+        return
+
     return scan(cve, conf, lp_filter, download)
+
+
+def scan_bugzilla():
+    table = []
+    pool = {}
+
+    bugs = get_pending_bugs()
+
+    logging.info("Scanning %d bugs...", len(bugs))
+
+    # Restrict logging to just errors
+    logging.getLogger().setLevel(logging.ERROR)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for b in bugs:
+            cve, system, cvss, level, prio  = get_bug_data(b)
+            if not cve:
+                continue
+            job = executor.submit(scan_job, b, cve)
+            pool[job] = [b.id, cve, system, cvss, level, prio]
+
+        for job in concurrent.futures.as_completed(pool):
+            bug = pool[job]
+            bug.extend(job.result())
+            table.append(bug)
+
+    # Restore the original log level
+    logging.getLogger().setLevel(logging.INFO)
+
+    logging.info(tabulate.tabulate(table, headers=["ID", "CVE", "SUBSYSTEM", "CVSS", "PRIORITY",
+                                                   "CLASSIFICATION", "STATUS", "AFFECTED"]))
+
+
+def scan_job(bug, cve):
+    affected = "No"
+    status = "Not-Fixed"
+
+    patches, _, _, affected_cs = scan(cve, None, None, False)
+
+    # Check if parent bug has been discarded
+    dep = get_bug_dep(bug)
+    if is_bug_dropped(dep):
+        status = "Dropped"
+
+    npatches = len(set(f for _, files in patches.items() for f in files))
+    if npatches:
+        status = f"Fixed({npatches})"
+
+    if dep and "security-team" not in dep.assigned_to:
+        status = f"Incomplete({npatches})"
+
+    if affected_cs:
+        affected = utils.classify_codestreams_str(affected_cs)
+
+    return status, affected
 
 
 def scan(cve, conf, lp_filter, download, savedir=None):
@@ -116,10 +177,9 @@ def scan(cve, conf, lp_filter, download, savedir=None):
         logging.info("\t%s", utils.classify_codestreams_str(unaffected_cs))
 
     if not working_cs:
-        logging.info("All supported codestreams are already patched. Exiting klp-build")
-        sys.exit(0)
-
-    logging.info("All affected codestreams:")
-    logging.info("\t%s", utils.classify_codestreams_str(working_cs))
+        logging.info("All supported codestreams are already patched.")
+    else:
+        logging.info("All affected codestreams:")
+        logging.info("\t%s", utils.classify_codestreams_str(working_cs))
 
     return patches, upstream, patched_cs, working_cs

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -43,8 +43,7 @@ def scan(cve, conf, lp_filter, download, savedir=None):
     # Support CVEs from 2020 up to 2029
     assert cve and re.match(r"^202[0-9]-[0-9]{4,7}$", cve)
 
-    patches = get_patches(cve, savedir)
-    upstream = patches.get("upstream", [])
+    upstream, patches = get_patches(cve, savedir)
 
     all_codestreams = get_supported_codestreams()
     filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)
@@ -123,4 +122,4 @@ def scan(cve, conf, lp_filter, download, savedir=None):
     logging.info("All affected codestreams:")
     logging.info("\t%s", utils.classify_codestreams_str(working_cs))
 
-    return upstream, patched_cs, working_cs
+    return patches, upstream, patched_cs, working_cs

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -134,9 +134,9 @@ def setup_codestreams(lp_name, data):
         all_codestreams = get_supported_codestreams()
         codestreams = utils.filter_codestreams(data["lp_filter"], all_codestreams)
     else:
-        upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
-                                                 data["lp_filter"], True,
-                                                 utils.get_workdir(lp_name))
+        _, upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
+                                                    data["lp_filter"], True,
+                                                    utils.get_workdir(lp_name))
 
     # Add new codestreams to the already existing list, skipping duplicates
     old_patched_cs = get_codestreams_data('patched_cs')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
         "filelock",
         "pyelftools",
         "zstandard",
-        "python-bugzilla"
+        "python-bugzilla",
+        "tabulate"
     ],
     setuptools_git_versioning={
         "enabled": True,

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -3,12 +3,30 @@
 # Copyright (C) 2025 SUSE
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
-from klpbuild.klplib.bugzilla import get_bug_title
-from klpbuild.klplib.utils import get_lp_number
+from klpbuild.klplib.bugzilla import (get_bug, get_bug_title, get_pending_bugs,
+                                      get_bug_data, get_bug_dep, get_bug_desc)
+
+def test_get_pending_bugs():
+    bugs = get_pending_bugs()
+    assert len(bugs) > 0
+
 
 def test_get_bug_title():
-    assert get_bug_title("1227320") == "wifi: mac80211: check/clear fast rx for non-4addr sta VLAN changes"
-    assert get_bug_title(get_lp_number("bsc1227320")
-                         ) == "wifi: mac80211: check/clear fast rx for non-4addr sta VLAN changes"
-    assert get_bug_title("bla") == "Change me!"
-    assert get_bug_title(get_lp_number("bla")) == "Change me!"
+    bug = get_bug("1227320")
+    assert bug and get_bug_title(bug) == "wifi: mac80211: check/clear fast rx for non-4addr sta VLAN changes"
+    assert get_bug_title(get_bug("blah")) == "Change me!"
+
+
+def test_get_bug_data():
+    bug = get_bug("1227320")
+    cve, subsys, cvss, level, prio = get_bug_data(bug)
+    assert (cve == "2024-35789" and subsys == "wifi"
+            and cvss == "7.8" and level == "trivial"
+            and prio == "Medium")
+
+
+def test_get_bug_desc():
+    expected = "In the Linux kernel, the following vulnerability has been resolved:"
+    bug = get_bug("1227320")
+    desc = get_bug_desc(bug)
+    assert desc and expected in desc

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -6,7 +6,6 @@
 from klpbuild.klplib.bugzilla import get_bug_title
 from klpbuild.klplib.utils import get_lp_number
 
-
 def test_get_bug_title():
     assert get_bug_title("1227320") == "wifi: mac80211: check/clear fast rx for non-4addr sta VLAN changes"
     assert get_bug_title(get_lp_number("bsc1227320")

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -35,6 +35,11 @@ def test_is_module_supported():
     # Expected: "+external	net/tipc/tipc"
     assert not ksrc_is_module_supported(mod, "6.4.0-150600.23.65")
 
+    mod = "net/netfilter/ipset/ip_set_bitmap_ip"
+    # Expected: "+base	net/netfilter/ipset/ip_set_bitmap_ip    # ipset: IP bitmap"
+    assert ksrc_is_module_supported(mod, "6.4.0-10")
+
+
 def test_get_rt_patches():
     expected = [
             "patches.suse/bpf-Check-bloom-filter-map-value-size.patch",

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -9,8 +9,7 @@ from klpbuild.plugins.scan import scan
 
 # This CVE is already covered on all codestreams
 def test_scan_all_cs_patched(caplog):
-    with pytest.raises(SystemExit):
-        scan("2022-48801", "", False, "", False)
+    scan("2022-48801", "", False, "", False)
 
     assert "All supported codestreams are already patched" in caplog.text
 


### PR DESCRIPTION
Add new functionality to scan command. By default, with no options set, it will fetch all the list of pending
CVEs from bugzilla and analyse each one of them. Once done, it will print a report.

```
     ID  CVE         SUBSYSTEM       CVSS    PRIORITY      CLASSIFICATION    STATUS         AFFECTED
-------  ----------  ------------  ------   ----------   ----------------  -------------  --------------------
122xxxx  2021-xxxxx  scsi             7.8    Medium         complex          Incomplete(0)  No
122xxxx  2024-xxxxx  drm/amdgpu       7.8    Medium         trivial          Fixed(3)       15.6rtu0 15.6u0
122xxxx  2024-xxxxx  iommu/vt-d       7.8    High           None             Fixed(1)       15.6rtu0 15.6u0-1
```

It takes around 3-4min to scan 90 CVEs.