### PR TITLE
klplib: ksrc: fetch all tags

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -72,9 +72,8 @@ def __fetch_kernel_branches():
         return
 
     # Mount the command to fetch all branches for supported codestreams
-    ret = subprocess.run(["/usr/bin/git", "-C", str(kern_src), "fetch",
-                          "--quiet", "--atomic", "--force", "--tags", "origin"] +
-                         list(KERNEL_BRANCHES.values()),
+    ret = subprocess.run(["/usr/bin/git", "-C", kern_src, "fetch",
+                          "--quiet", "--atomic", "--force", "--tags"],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
                          text=True)


### PR DESCRIPTION
Since functions like ksrc_read_rpm_file and alike have been introduced in ksrc module, we need to fetch all tags, not only the product branches.