### PR TITLE
Automation (1/3): Scan: Report modified functions

### DIFF
--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -33,11 +33,14 @@ def _find_config(cs, base_dir, relative_obj_path, deep):
     if deep > 10:
         return None, ""
 
+    if Path(".") == base_dir:
+        return "CONFIG_SUSE_KERNEL", "vmlinux"
+
     make_file = Path(base_dir, "Makefile")
 
     lines = _load_makefile(cs, make_file)
 
-    if not lines and Path(".") != base_dir:
+    if not lines:
         relative_obj_path = base_dir.name + "/" + relative_obj_path
         return _find_config(cs, base_dir.parent, relative_obj_path, deep+1)
 
@@ -48,6 +51,9 @@ def _find_config(cs, base_dir, relative_obj_path, deep):
 
         # target found, check if this one with config
         target = sep[0]
+        if target.startswith('obj-y'):
+            # If it's built-in then check the config of the parent directory
+            return _find_config(cs, base_dir.parent, base_dir.name + '/', deep)
         if target.startswith('obj-'):
             return _sanitize_config(target), str((base_dir/relative_obj_path).with_suffix(''))
 
@@ -70,18 +76,19 @@ def find_configs_for_files(cs, file_paths: list):
     missing = []
 
     if not file_paths:
-        return configs, build_ins, missing
+        return configs, missing
 
     for path in file_paths:
         path = path.strip()
+        # Do not check headers
+        if path.endswith('h'):
+            continue
         obj_file = Path(path.replace('.c', '.o'))
         config, obj = _find_config(cs, obj_file.parent, obj_file.name, 0)
         if not config:
             missing.append(path)
-        elif config == 'y' or config == 'm':
-            build_ins.append(path)
         elif config.startswith('CONFIG_'):
             configs[path] = {'config': config, 'obj': obj}
         # else there is garbage like 'subst', 'vds' for wrongly parsed input
 
-    return configs, build_ins, missing
+    return configs, missing

--- a/tests/test_kernel_tree.py
+++ b/tests/test_kernel_tree.py
@@ -3,9 +3,22 @@
 # Copyright (C) 2021-2024 SUSE
 # Author: Marcos Paulo de Souza
 
-from klpbuild.klplib.kernel_tree import get_commit_data
+from klpbuild.klplib.kernel_tree import get_commit_data, get_commit_body, find_commit
 
 def test_multiline_upstream_commit_subject():
-    _, subj = get_commit_data("49c47cc21b5b")
+    _, subj, _ = get_commit_data("49c47cc21b5b")
     assert subj == "net: tls: fix possible race condition between do_tls_getsockopt_conf() and do_tls_setsockopt_conf()"
 
+
+def test_find_commit():
+    subj = "tcp/dccp: Don't use timer_pending() in reqsk_queue_unlink()."
+    assert "af9aa67aec10" in find_commit(subj, "SLE15-SP7")
+
+    subj = "ALSA: firewire-lib: Avoid division by zero in apply_constraint_to_size()"
+    assert "76935334e479" in find_commit(subj, "SLE15-SP6")
+
+
+def test_get_commit_body():
+    file = "net/ipv4/inet_connection_sock.c"
+    func = "return __inet_csk_reqsk_queue_drop(sk, req, false);"
+    assert func in get_commit_body("af9aa67aec100", file)


### PR DESCRIPTION
Hi guys,

With this PR the `scan` command is now able to report the modified functions of each affected file:

```
6.0rtu2-8 6.0u2-7 15.3u48-58 15.4u31-41 15.5u19-27 15.6rtu2-10 15.6u4-11 15.7rtu0 15.7u0:
FILE: net/sched/sch_ets.c
CONF: CONFIG_NET_SCH_ETS
OBJ: net/sched/sch_ets
FUNCS: ets_qdisc_change, ets_qdisc_dequeue, ets_qdisc_reset, ets_class_qlen_notify
```

The modified functions are found by:
1. Locating the commit introducing the patch in kernel.git. This is done by greping for the `subject` field.
2. Parsing the content/diff of each modified file in the commit, with full function context.

Limitations:
- There is no noticeable slowdown, except in some few cases, due to [this code]( https://github.com/SUSE/klp-build/compare/devel...fgyanz:scan-funcs?expand=1#diff-6e296f3d424cade938c4e89b0eb23e20dc210d23a0d88d82a0c9b6159aa2aa4bR116-R126). Worst case I've seen is around 1 minute. I think it's within an acceptable margin, and we can probably improve it.
- False-positives? False-negatives? None so far, but I'm sure there must be some. For the record, I've tested around 30 CVEs, and with the last iteration 0 issues.

Please, let me know your thoughts. I have a second PR almost ready where the `setup` is fully automated based on the scan report. Meaning that the `--file-funcs`, `--config` and `--module` parameters will be optional and only meant for corner cases were the scan report is wrong.
