### PR TITLE
Automation (2/3): setup

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -134,12 +134,20 @@ During the setup,
 .B klp-build
 analysis each codestream in order to identify those affected by
 the indicated CVE. Note that in this phase a lot of per-codestream
-data is generated and stored for future use.
+data is generated and stored for future use. By default,
+.B setup
+retrieves all the technical information (files, functions, configs,
+modules and archs) from the report generated during the
+.B scan.
+In case the report is incorrect, the values can be passed manually
+with the optional arguments.
 .RS 7
 .TP
 .BI --cve " CVE"
 The CVE assigned to this livepatch.
 .TP
+Optional arguments:
+.PP
 .BI --conf " CONF"
 The kernel CONFIG used to build the object to be livepatched.
 .TP
@@ -274,9 +282,16 @@ kernel module
 .IP
 $
 .B klp-build
+setup --name bsc1197597 --cve 2022-1048 --filter '15.5' --archs x86_64 ppc64le
+.PP
+Or if the automated setup is incorrected, the information can be
+passed manually:
+.IP
+$
+.B klp-build
 setup --name bsc1197597 --cve 2022-1048 --mod snd-pcm --conf
 CONFIG_SND_PCM --file-funcs sound/core/pcm.c snd_pcm_attach_substream
-snd_pcm_detach_substream --codestreams '15.5' --archs x86_64 ppc64le
+snd_pcm_detach_substream --filter '15.5' --archs x86_64 ppc64le
 .PP
 Compare two codestreams:
 .IP

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -348,39 +348,6 @@ class Codestream:
 
         return configs
 
-    def validate_config(self, archs, conf, mod):
-        configs = {}
-        cs_config = self.get_all_configs(conf)
-
-        # Validate only the specified architectures, but check if the codestream
-        # is supported on that arch (like RT that is currently supported only on
-        # x86_64)
-        for arch in archs:
-            # Check if the desired CONFIG entry is set on the codestreams's supported
-            # architectures, by iterating on the specified architectures from the setup command.
-            if arch not in self.archs:
-                continue
-
-            try:
-                conf_entry = cs_config.pop(arch)
-            except KeyError as exc:
-                raise RuntimeError(f"{self.full_cs_name()}: {conf} not set on {arch}. Aborting") from exc
-
-            if conf_entry == "m" and mod == "vmlinux":
-                raise RuntimeError(f"{self.full_cs_name()}:{arch} ({self.kernel}): Config {conf} is set as module, but no module was specified")
-            if conf_entry == "y" and mod != "vmlinux":
-                raise RuntimeError(f"{self.full_cs_name()}:{arch} ({self.kernel}): Config {conf} is set as builtin, but a module {mod} was specified")
-
-            configs.setdefault(conf_entry, [])
-            configs[conf_entry].append(f"{self.full_cs_name()}:{arch}")
-
-        # Validate if we have different settings for the same config on
-        # different architecures, like having it as builtin on one and as a
-        # module on a different arch.
-        if len(configs.keys()) > 1:
-            print(configs["y"])
-            print(configs["m"])
-            raise RuntimeError(f"{self.full_cs_name()}: Configuration mismatach between codestreams. Aborting.")
 
     def find_obj_path(self, arch, mod):
         # Return the path if the modules was previously found for ARCH, or refetch if

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -312,6 +312,13 @@ class Codestream:
     def get_mod(self, mod):
         return self.modules[mod]
 
+
+    def get_file_mod(self, file, arch=ARCH):
+        fdat = self.files[file]
+        conf_arch = self.configs[fdat["conf"]][arch]
+        return "vmlinux" if conf_arch == 'y' else fdat["module"]
+
+
     def is_module_supported(self, mod):
         return ksrc_is_module_supported(mod, self.kernel)
 

--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -88,7 +88,7 @@ def find_configs_for_files(cs, file_paths: list):
         if not config:
             missing.append(path)
         elif config.startswith('CONFIG_'):
-            configs[path] = {'config': config, 'obj': obj}
+            configs[path] = {'conf': config, 'module': obj}
         # else there is garbage like 'subst', 'vds' for wrongly parsed input
 
     return configs, missing

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -40,9 +40,9 @@ def analyse_files(cs_list, sle_patches):
             for file, funcs in files_funcs.items():
                 conf = files_conf.get(file, {})
                 if conf:
-                    cs.files[file] = {'symbols': funcs}
+                    cs.files[file] = {'symbols': list(funcs)}
                     cs.files[file].update(conf)
-                    key = f"{file}:{conf['config']}:{conf['obj']}:{sorted(funcs)}"
+                    key = f"{file}:{conf['conf']}:{conf['module']}:{sorted(funcs)}"
                 else:
                     key = f"{file}:::"
 
@@ -64,8 +64,8 @@ def print_files(report):
             logging.info(f"{cs_str}:\nFILE: {file}\n")
             continue
 
-        conf = cs.files[file]['config']
-        obj = cs.files[file]['obj']
+        conf = cs.files[file]['conf']
+        obj = cs.files[file]['module']
         funcs = cs.files[file]['symbols']
         logging.info("%s:\nFILE: %s\nCONF: %s\nOBJ: %s\nFUNCS: %s\n",
                      cs_str, file, conf, obj, ', '.join(funcs))
@@ -86,7 +86,7 @@ def analyse_configs(cs_list):
     report = defaultdict(list)
 
     for cs in cs_list:
-        configs = {dat['confing'] for _, dat in cs.files.items()}
+        configs = {dat['conf'] for _, dat in cs.files.items()}
         cs.set_configs(configs)
         for conf, archs in cs.configs.items():
             key = f"{conf}:{archs}"
@@ -150,8 +150,8 @@ def analyse_kmodules(cs_list):
 
     for cs in cs_list:
         for _, dat in cs.files.items():
-            conf = dat['config']
-            mod = dat['obj']
+            conf = dat['conf']
+            mod = dat['module']
             if mod in cs.modules:
                 continue
 
@@ -191,6 +191,9 @@ def filter_unsupported_kmodules(cs_list):
         supported = [s for _, s in cs.modules.items() if s]
         if not supported:
             unset_cs.append(cs)
+
+        # Cleanup for future re-use
+        cs.modules.clear()
 
     for cs in unset_cs:
         cs_list.remove(cs)

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -86,14 +86,10 @@ def analyse_configs(cs_list):
     report = defaultdict(list)
 
     for cs in cs_list:
-        for _, dat in cs.files.items():
-            conf = dat['config']
-            if conf in cs.configs:
-                continue
-
-            cs.configs[conf] = cs.get_all_configs(conf)
-
-            key = f"{conf}:{cs.configs[conf]}"
+        configs = {dat['confing'] for _, dat in cs.files.items()}
+        cs.set_configs(configs)
+        for conf, archs in cs.configs.items():
+            key = f"{conf}:{archs}"
             if cs not in report[key]:
                 report[key].append(cs)
 

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -225,6 +225,16 @@ def filter_codestreams(lp_filter, cs_list, verbose=False):
 
     return result
 
+
+def affected_archs(cs_list):
+    conf_archs = set()
+    for cs in cs_list:
+        for val in cs.configs.values():
+            conf_archs.update(val)
+
+    return sorted(conf_archs)
+
+
 def get_mail():
     git_data = git.GitConfigParser()
     user = git_data.get_value("user", "name")

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -467,11 +467,12 @@ def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
 
     # Needed, otherwise threads would interfere with each other
     env = os.environ.copy()
+    obj = cs.get_file_mod(fname)
 
     env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt() else "0"
     env["KCP_MOD_SYMVERS"] = str(cs.get_boot_file("symvers"))
     env["KCP_KBUILD_ODIR"] = str(cs.get_obj_dir())
-    env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.ARCH)/cs.get_mod(fdata["module"]))
+    env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.ARCH)/cs.get_mod(obj))
     env["KCP_KBUILD_SDIR"] = str(cs.get_src_dir())
     env["KCP_IPA_CLONES_DUMP"] = str(cs.get_ipa_file(fname))
     env["KCP_WORK_DIR"] = str(out_dir)

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -115,6 +115,7 @@ def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
     unaffected_cs = []
     for cs in filtered_codesteams:
 
+        # Skip codestreams that do not support the given archs.
         cs.set_archs(archs)
         if not cs.archs:
             continue

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -100,7 +100,7 @@ def scan_job(bug, cve):
     return status, affected
 
 
-def scan(cve, conf, lp_filter, download, savedir=None):
+def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
     # Support CVEs from 2020 up to 2029
     assert cve and re.match(r"^202[0-9]-[0-9]{4,7}$", cve)
 
@@ -114,6 +114,10 @@ def scan(cve, conf, lp_filter, download, savedir=None):
     patched_cs = []
     unaffected_cs = []
     for cs in filtered_codesteams:
+
+        cs.set_archs(archs)
+        if not cs.archs:
+            continue
 
         if cs.kernel in patched_kernels:
             patched_cs.append(cs.full_cs_name())
@@ -149,11 +153,13 @@ def scan(cve, conf, lp_filter, download, savedir=None):
         patch.print_kmodules(kmodules_report)
         unsupported = patch.filter_unsupported_kmodules(working_cs)
 
+        working_archs = utils.affected_archs(working_cs)
+        logging.info("Affected architectures:")
+        logging.info("\t%s", ' '.join(working_archs))
     # If conf is set, drop codestream not containing that conf entry from working_cs
     elif conf:
         tmp_working_cs = []
         for cs in working_cs:
-            # TODO: here we could check for affected arch automatically
             if not cs.get_all_configs(conf):
                 conf_not_set.append(cs)
             else:
@@ -180,6 +186,6 @@ def scan(cve, conf, lp_filter, download, savedir=None):
         logging.info("All supported codestreams are already patched.")
     else:
         logging.info("All affected codestreams:")
-        logging.info("\t%s", utils.classify_codestreams_str(working_cs))
+        logging.info("\t%s\n", utils.classify_codestreams_str(working_cs))
 
     return patches, upstream, patched_cs, working_cs

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -87,8 +87,9 @@ def setup(lp_name, lp_filter, no_check, archs, cve, conf, module, file_funcs,
 
     codestreams = setup_codestreams(lp_name, {"cve": cve, "conf": conf,
                                               "lp_filter": lp_filter,
-                                              "no_check": no_check})
-    setup_project_files(lp_name, codestreams, ffuncs, archs)
+                                              "no_check": no_check,
+                                              "archs": archs})
+
 
 def setup_file_funcs(conf, mod, file_funcs, mod_file_funcs, conf_mod_file_funcs):
     if conf and not conf.startswith("CONFIG_"):
@@ -136,6 +137,7 @@ def setup_codestreams(lp_name, data):
     else:
         _, upstream, patched_cs, codestreams = scan(data["cve"], data["conf"],
                                                     data["lp_filter"], True,
+                                                    data["archs"],
                                                     utils.get_workdir(lp_name))
 
     # Add new codestreams to the already existing list, skipping duplicates

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -10,7 +10,12 @@ from klpbuild.klplib.ibs import get_cs_packages
 from klpbuild.plugins.setup import setup_codestreams
 
 CS = "15.6u15"
-DEFAULT_DATA = {"cve": None, "lp_filter": CS, "lp_skips": None, "conf": None, "no_check": True}
+DEFAULT_DATA = {"cve": None,
+                "lp_filter": CS,
+                "lp_skips": None,
+                "conf": None,
+                "no_check": True,
+                "archs": None}
 
 
 def test_list_of_packages():

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -9,7 +9,7 @@ from klpbuild.plugins.scan import scan
 
 # This CVE is already covered on all codestreams
 def test_scan_all_cs_patched(caplog):
-    scan("2022-48801", "", False, "", False)
+    scan("2022-48801", "", "", False)
 
     assert "All supported codestreams are already patched" in caplog.text
 

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -273,7 +273,7 @@ def test_templ_ibt_without_externalized_vars():
         assert check not in content
 
     # As the config only targets one arch, IS_ENABLED should be set
-    assert "#if IS_ENABLED" not in content
+    assert "#if IS_ENABLED" in content
 
     # Without CVE speficied, we should have XXXX-XXXX
     assert "CVE-XXXX-XXXX" in content


### PR DESCRIPTION
From now on, setup will no longer require more parameters other than '--cve' and '--name'. The livepatch technical information (that is: files, functions, configs, modules and archs) will be directly retrieved from the report generated by scan(). The user will only need to double-check that the livepatch information is actually correct. In case it is not,
there's still as a fallback option the manual input ('--conf', '--file-func', etc).

This PR depends on https://github.com/SUSE/klp-build/pull/154.