### PR TITLE
Store required patches in codestream object

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -305,6 +305,12 @@ class Codestream:
 
         return pkg
 
+
+    def has_patch(self, patch):
+        kernel_version = self.kernel
+        return bool(ksrc_read_rpm_file(kernel_version, patch))
+
+
     def needs_ibt(self):
         return self.is_slfo or (self.sle == 15 and self.sp >= 6)
 

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -555,3 +555,24 @@ class Codestream:
 
     def needs_patches(self):
         return bool(self.required_patches)
+
+    def get_candidate_patches_dirs(self):
+        """
+        Returns the list of names of the directories containing the patches to
+        be applied for the current codestream ordered by priority.
+
+        Beware, the entries do not represent the full path.
+        """
+        dirs = []
+
+        if self.rt:
+            dirs.extend([f"{self.sle}.{self.sp}rtu{self.update}", f"{self.sle}.{self.sp}rt"])
+
+        dirs.extend([f"{self.sle}.{self.sp}u{self.update}", f"{self.sle}.{self.sp}"])
+
+        if self.sle == 15 and self.sp < 4:
+            dirs.append("cve-5.3")
+        elif self.sle == 15 and self.sp <= 5:
+            dirs.append("cve-5.14")
+
+        return dirs

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -20,10 +20,11 @@ from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag,
 class Codestream:
     __slots__ = ("__name", "sle", "sp", "update", "rt", "is_micro", "is_slfo",
                  "__project", "patchid", "kernel", "archs", "files", "modules",
-                 "repo", "configs")
+                 "repo", "configs", "required_patches")
 
     def __init__(self, name, project="", patchid="", kernel="",
-                 archs=None, files=None, modules=None, configs=None):
+                 archs=None, files=None, modules=None, configs=None,
+                 required_patches=None):
 
         self.__name = name
 
@@ -49,12 +50,14 @@ class Codestream:
         self.modules = modules if modules is not None else {}
         self.configs = configs if configs is not None else {}
 
+        self.required_patches = required_patches if required_patches is not None else []
+
 
     @classmethod
     def from_data(cls, data):
         return cls(data["name"],data["project"], data["patchid"],
                    data["kernel"], data["archs"], data["files"],
-                   data["modules"], data["configs"])
+                   data["modules"], data["configs"], data["required_patches"])
 
     def to_data(self):
         # archs needs to be turned into a list, since a set is not serializable
@@ -67,6 +70,7 @@ class Codestream:
                 "files" : self.files,
                 "modules" : self.modules,
                 "configs" : self.configs,
+                "required_patches" : self.required_patches
                 }
 
     def __eq__(self, cs):
@@ -536,3 +540,13 @@ class Codestream:
 
     def read_file(self, file):
         return read_file_in_tag(self.kernel, file)
+
+    def add_required_patch(self, patch):
+        patch_name = Path(patch).name
+        self.required_patches.append(patch_name)
+
+    def get_required_patches(self):
+        return self.required_patches[:]
+
+    def needs_patches(self):
+        return bool(self.required_patches)

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -16,6 +16,7 @@ from importlib import resources
 from klpbuild.klplib.ksrc import ksrc_read_rpm_file, ksrc_is_module_supported
 from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_elf_object, get_datadir, preferred_arch
 from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
+from klpbuild.klplib.ksrc import KERNEL_BRANCHES
 
 class Codestream:
     __slots__ = ("__name", "sle", "sp", "update", "rt", "is_micro", "is_slfo",
@@ -308,6 +309,10 @@ class Codestream:
             pkg = f"{pkg}.{self.get_repo()}"
 
         return pkg
+
+
+    def get_base_branch(self):
+        return KERNEL_BRANCHES[self.base_cs_name()]
 
 
     def has_patch(self, patch):

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -299,16 +299,6 @@ def get_patches(cve, savedir=None):
     return upslogs, patches
 
 
-def cs_is_affected(cs, cve, patches):
-    # We can only check if the cs is affected or not if the CVE was informed
-    # (so we can get all commits related to that specific CVE). Otherwise we
-    # consider all codestreams as affected.
-    if not cve:
-        return True
-
-    return len(patches[cs.base_cs_name()]) > 0
-
-
 def ksrc_read_rpm_file(kernel_version, file_path):
     return __read_file("rpm-" + kernel_version, file_path)
 

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -319,6 +319,8 @@ def get_patched_kernels(codestreams, patches):
         logging.debug("\n%s (%s):", cs.full_cs_name(), kernel)
         for patch in suse_patches:
             if not cs.has_patch(patch):
+                # Store the patches required by this codestreams for future use
+                cs.add_required_patch(patch)
                 break
             logging.debug(patch)
         else:

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -318,7 +318,7 @@ def get_patched_kernels(codestreams, patches):
 
         logging.debug("\n%s (%s):", cs.full_cs_name(), kernel)
         for patch in suse_patches:
-            if not ksrc_read_rpm_file(kernel, patch):
+            if not cs.has_patch(patch):
                 break
             logging.debug(patch)
         else:

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -308,7 +308,7 @@ def get_patched_kernels(codestreams, patches):
     kernels = set()
 
     for cs in codestreams:
-        bc = cs.full_cs_name().split("u")[0]
+        bc = cs.base_cs_name()
         suse_patches = patches[bc]
         if not suse_patches:
             continue

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -299,38 +299,6 @@ def get_patches(cve, savedir=None):
     return upslogs, patches
 
 
-def get_patched_kernels(codestreams, patches):
-    if not patches:
-        return []
-
-    logging.info("Searching for already patched codestreams...")
-
-    kernels = set()
-
-    for cs in codestreams:
-        bc = cs.base_cs_name()
-        suse_patches = patches[bc]
-        if not suse_patches:
-            continue
-
-        # Proceed to analyse each codestream's kernel
-        kernel = cs.kernel
-
-        logging.debug("\n%s (%s):", cs.full_cs_name(), kernel)
-        for patch in suse_patches:
-            if not cs.has_patch(patch):
-                # Store the patches required by this codestreams for future use
-                cs.add_required_patch(patch)
-                break
-            logging.debug(patch)
-        else:
-            kernels.add(kernel)
-
-    logging.debug("")
-
-    return kernels
-
-
 def cs_is_affected(cs, cve, patches):
     # We can only check if the cs is affected or not if the CVE was informed
     # (so we can get all commits related to that specific CVE). Otherwise we

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -13,7 +13,7 @@ from klpbuild.klplib.file2config import find_configs_for_files
 from klpbuild.klplib.ksrc import get_patches_files
 
 
-def analyse_files(cs_list, sle_patches):
+def analyse_files(cs_list):
     '''
     Function that analyses, per codestream, each of the files modified
     by the backported patches.
@@ -30,8 +30,7 @@ def analyse_files(cs_list, sle_patches):
     report = defaultdict(list)
 
     for cs in cs_list:
-        bc = cs.base_cs_name()
-        patches = sle_patches[bc]
+        patches = [f"patches.suse/{p}" for p in cs.get_required_patches()]
         branch = cs.get_base_branch()
 
         files_funcs = get_patches_files(patches, branch)

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.file2config import find_configs_for_files
-from klpbuild.klplib.ksrc import KERNEL_BRANCHES, get_patches_files
+from klpbuild.klplib.ksrc import get_patches_files
 
 
 def analyse_files(cs_list, sle_patches):
@@ -32,7 +32,7 @@ def analyse_files(cs_list, sle_patches):
     for cs in cs_list:
         bc = cs.base_cs_name()
         patches = sle_patches[bc]
-        branch = KERNEL_BRANCHES[bc]
+        branch = cs.get_base_branch()
 
         files_funcs = get_patches_files(patches, branch)
         files_path = files_funcs.keys()

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -290,6 +290,26 @@ def filter_codestreams(lp_filter, cs_list, verbose=False):
     return result
 
 
+def filter_codestreams_by_arch(archs, cs_list):
+    '''
+    Filter the codestreams that do not have support for any arch in "archs".
+    E.g. this would filter out a real time codestreams if archs = ["ppc64le"],
+    since ppc64le does have real time support.
+
+    Beware that this function modifies cs.archs fiels in the codestream objects.
+    '''
+    result = []
+
+    for cs in cs_list:
+        # NOTE: should we adopt a different strategy here? This modifies the
+        # codestream object
+        cs.set_archs(archs)
+        if cs.archs:
+            result.append(cs)
+
+    return result
+
+
 def affected_archs(cs_list):
     conf_archs = set()
     for cs in cs_list:

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -535,22 +535,8 @@ def apply_patch(patch, sdir):
 
 
 def apply_all_patches(lp_name, cs):
-    dirs = []
-
-    if cs.rt:
-        dirs.extend([f"{cs.sle}.{cs.sp}rtu{cs.update}", f"{cs.sle}.{cs.sp}rt"])
-
-    dirs.extend([f"{cs.sle}.{cs.sp}u{cs.update}", f"{cs.sle}.{cs.sp}"])
-
-    if cs.sle == 15 and cs.sp < 4:
-        dirs.append("cve-5.3")
-    elif cs.sle == 15 and cs.sp <= 5:
-        dirs.append("cve-5.14")
-
-    patch_dirs = []
-
-    for d in dirs:
-        patch_dirs.append(Path(get_patches_dir(lp_name), d))
+    dirs = cs.get_candidate_patches_dirs()
+    patch_dirs = [Path(get_patches_dir(lp_name))/d for d in dirs]
 
     patched = False
     sdir = cs.get_src_dir()

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -535,12 +535,7 @@ def apply_patch(patch, sdir):
 
 
 def apply_all_patches(lp_name, cs):
-    dirs = cs.get_candidate_patches_dirs()
-    patch_dirs = [Path(get_patches_dir(lp_name))/d for d in dirs]
-
-    patched = False
     sdir = cs.get_src_dir()
-
     bname = get_lp_branch(lp_name, cs)
     err = subprocess.run(["git", "checkout", "-B", bname],
                          cwd=sdir,
@@ -550,30 +545,29 @@ def apply_all_patches(lp_name, cs):
     if err.returncode != 0:
         raise RuntimeError(f"Failed to create branch {bname}. Aborting")
 
-    for pdir in patch_dirs:
-        if not pdir.exists():
-            logging.debug("Patches dir %s doesnt exists", pdir)
+    dirs = cs.get_candidate_patches_dirs()
+    available_patch_dirs = [Path(get_patches_dir(lp_name))/d for d in dirs]
+
+    # Pick the first directory in available_patch_dirs that exists
+    patch_dir = None
+    while available_patch_dirs:
+        candidate_patch_dir = available_patch_dirs.pop(0)
+        if candidate_patch_dir.exists():
+            patch_dir = candidate_patch_dir
+            break
+    assert patch_dir, "Couldn't find a patch directory"
+
+    logging.debug("Applying patches on %s(%s) from %s", cs.full_cs_name(), cs.kernel, patch_dir)
+    # Here for the ordering we rely on the patches being previouly renamed with a prefix
+    for patch in sorted(patch_dir.iterdir()):
+        if not str(patch).endswith(".patch"):
             continue
 
-        logging.debug("Applying patches on %s(%s) from %s", cs.full_cs_name(), cs.kernel, pdir)
-
-        for patch in sorted(pdir.iterdir()):
-            if not str(patch).endswith(".patch"):
-                continue
-
-            logging.info("%s:%s: Applying %s...",
-                         cs.full_cs_name(), cs.kernel, patch)
-
-            if not (patched := apply_patch(str(patch), sdir)):
-                break
-
-        # Stop the loop in the first dir that we find patches.
-        break
-
-    if not patched:
-        raise RuntimeError(f"{cs.full_cs_name()}({cs.kernel}): "
-                           "Failed to apply patches. Aborting\n"
-                           f"For more information go to: {sdir}")
+        logging.info("%s:%s: Applying %s...", cs.full_cs_name(), cs.kernel, patch)
+        if not apply_patch(str(patch), sdir):
+            raise RuntimeError(f"{cs.full_cs_name()}({cs.kernel}): "
+                "Failed to apply patches. Aborting\n"
+                f"For more information go to: {sdir}")
 
 
 def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -557,17 +557,30 @@ def apply_all_patches(lp_name, cs):
             break
     assert patch_dir, "Couldn't find a patch directory"
 
-    logging.debug("Applying patches on %s(%s) from %s", cs.full_cs_name(), cs.kernel, patch_dir)
+    # Get the patches that need to be applied for the current codestream
+    required_patches = set(cs.get_required_patches())
+
+    logging.info("Applying patches on %s(%s) from %s", cs.full_cs_name(), cs.kernel, patch_dir)
     # Here for the ordering we rely on the patches being previouly renamed with a prefix
     for patch in sorted(patch_dir.iterdir()):
         if not str(patch).endswith(".patch"):
             continue
 
-        logging.info("%s:%s: Applying %s...", cs.full_cs_name(), cs.kernel, patch)
+        # Skip if the patch is not required for the current codestream
+        patch_name = patch.name.split("-",1)[1] # Drop the prefix from the patch
+        if patch_name not in required_patches:
+            logging.info("\tDropping %s", patch_name)
+            continue
+
+        logging.info("\tApplying %s", patch_name)
         if not apply_patch(str(patch), sdir):
             raise RuntimeError(f"{cs.full_cs_name()}({cs.kernel}): "
-                "Failed to apply patches. Aborting\n"
+                f"Failed to apply patch {patch_name}. Aborting\n"
                 f"For more information go to: {sdir}")
+
+        required_patches.discard(patch_name)
+
+    assert not required_patches, "Some required patches have not been applied"
 
 
 def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -117,6 +117,9 @@ def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
 
     affected_cs, unaffected_cs, patched_cs = filter_affected_codestreams(filtered_codesteams, patches)
 
+    # FIXME: the following statemend is no longer true since the config is
+    # retrieved from the kernel-source:
+    #
     # Download also if conf is set, because the codestreams data are needed to
     # check for the configuration entry of each codestreams.
     if conf or download:

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -128,7 +128,7 @@ def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
     if patches and not conf:
         logging.info("Initiating patch analysis...\n")
         logging.info("[*] Analysing modified files...\n")
-        files_report = patch.analyse_files(affected_cs, patches)
+        files_report = patch.analyse_files(affected_cs)
         patch.print_files(files_report)
 
         logging.info("[*] Analysing required CONFIGs...\n")

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -181,10 +181,6 @@ def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
 
 
 def filter_affected_codestreams(codestreams, patches):
-    # TODO: remove this
-    if not patches:
-        return []
-
     logging.info("Filtering already patched codestreams...")
     affected_codestreams = []   # Codestreams without all the patches
     unaffected_codestreams = [] # Codestreams belonging to a non affected product

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -106,38 +106,21 @@ def scan_job(bug, cve):
     return status, affected_archs, affected
 
 
-def scan(cve, conf, lp_filter, download, archs=None, savedir=None):
-
+def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
     assert cve and utils.is_cve_valid(cve)
-
-    if not archs:
-        archs = utils.ARCHS
 
     upstream, patches = get_patches(cve, savedir)
 
     all_codestreams = get_supported_codestreams()
     filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)
     filtered_codesteams = utils.filter_codestreams_by_arch(archs, filtered_codesteams)
-    patched_kernels = get_patched_kernels(filtered_codesteams, patches)
 
-    working_cs = []
-    patched_cs = []
-    unaffected_cs = []
-    for cs in filtered_codesteams:
-        if cs.kernel in patched_kernels:
-            patched_cs.append(cs.full_cs_name())
-            continue
-
-        if not cs_is_affected(cs, cve, patches):
-            unaffected_cs.append(cs)
-            continue
-
-        working_cs.append(cs)
+    affected_cs, unaffected_cs, patched_cs = filter_affected_codestreams(filtered_codesteams, patches)
 
     # Download also if conf is set, because the codestreams data are needed to
     # check for the configuration entry of each codestreams.
     if conf or download:
-        download_missing_cs_data(working_cs)
+        download_missing_cs_data(affected_cs)
 
     # Automated patch analysis phase. Not compatible with --conf.
     conf_not_set = []
@@ -145,31 +128,32 @@ def scan(cve, conf, lp_filter, download, archs=None, savedir=None):
     if patches and not conf:
         logging.info("Initiating patch analysis...\n")
         logging.info("[*] Analysing modified files...\n")
-        files_report = patch.analyse_files(working_cs, patches)
+        files_report = patch.analyse_files(affected_cs, patches)
         patch.print_files(files_report)
 
         logging.info("[*] Analysing required CONFIGs...\n")
-        configs_report = patch.analyse_configs(working_cs)
+        configs_report = patch.analyse_configs(affected_cs)
         patch.print_configs(configs_report)
-        conf_not_set, conf = patch.filter_unset_configs(working_cs)
+        conf_not_set, conf = patch.filter_unset_configs(affected_cs)
 
         logging.info("[*] Analysing affected kernel modules...\n")
-        kmodules_report = patch.analyse_kmodules(working_cs)
+        kmodules_report = patch.analyse_kmodules(affected_cs)
         patch.print_kmodules(kmodules_report)
-        unsupported = patch.filter_unsupported_kmodules(working_cs)
+        unsupported = patch.filter_unsupported_kmodules(affected_cs)
 
-        working_archs = utils.affected_archs(working_cs)
+        working_archs = utils.affected_archs(affected_cs)
         logging.info("Affected architectures:")
         logging.info("\t%s", ' '.join(working_archs))
+
     # If conf is set, drop codestream not containing that conf entry from working_cs
     elif conf:
-        tmp_working_cs = []
-        for cs in working_cs:
+        tmp_affected_cs = []
+        for cs in affected_cs:
             if not cs.get_all_configs(conf):
                 conf_not_set.append(cs)
             else:
-                tmp_working_cs.append(cs)
-        working_cs = tmp_working_cs
+                tmp_affected_cs.append(cs)
+        affected_cs = tmp_affected_cs
 
     if unsupported:
         logging.info("Skipping codestreams with unsupported kernel modules:")
@@ -187,52 +171,43 @@ def scan(cve, conf, lp_filter, download, archs=None, savedir=None):
         logging.info("Skipping unaffected codestreams (missing backports):")
         logging.info("\t%s", utils.classify_codestreams_str(unaffected_cs))
 
-    if not working_cs:
+    if not affected_cs:
         logging.info("All supported codestreams are already patched.")
     else:
         logging.info("All affected codestreams:")
-        logging.info("\t%s\n", utils.classify_codestreams_str(working_cs))
+        logging.info("\t%s\n", utils.classify_codestreams_str(affected_cs))
 
-    return patches, upstream, patched_cs, working_cs
+    return patches, upstream, patched_cs, affected_cs
 
 
-def get_patched_kernels(codestreams, patches):
+def filter_affected_codestreams(codestreams, patches):
+    # TODO: remove this
     if not patches:
         return []
 
-    logging.info("Searching for already patched codestreams...")
-
-    kernels = set()
+    logging.info("Filtering already patched codestreams...")
+    affected_codestreams = []   # Codestreams without all the patches
+    unaffected_codestreams = [] # Codestreams belonging to a non affected product
+    patched_codestreams = []    # Codestreams with all the patches
 
     for cs in codestreams:
-        bc = cs.base_cs_name()
-        suse_patches = patches[bc]
+        suse_patches = patches[cs.base_cs_name()]
+
         if not suse_patches:
+            unaffected_codestreams.append(cs)
             continue
 
-        # Proceed to analyse each codestream's kernel
-        kernel = cs.kernel
-
-        logging.debug("\n%s (%s):", cs.full_cs_name(), kernel)
+        logging.debug("%s (%s) requires:", cs.full_cs_name(), cs.kernel)
         for patch in suse_patches:
             if not cs.has_patch(patch):
                 # Store the patches required by this codestreams for future use
                 cs.add_required_patch(patch)
-                break
-            logging.debug(patch)
+                logging.debug("\t%s", patch)
+        logging.debug("")
+
+        if cs.needs_patches():
+            affected_codestreams.append(cs)
         else:
-            kernels.add(kernel)
+            patched_codestreams.append(cs)
 
-    logging.debug("")
-
-    return kernels
-
-
-def cs_is_affected(cs, cve, patches):
-    # We can only check if the cs is affected or not if the CVE was informed
-    # (so we can get all commits related to that specific CVE). Otherwise we
-    # consider all codestreams as affected.
-    if not cve:
-        return True
-
-    return len(patches[cs.base_cs_name()]) > 0
+    return affected_codestreams, unaffected_codestreams, patched_codestreams

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -117,18 +117,13 @@ def scan(cve, conf, lp_filter, download, archs=None, savedir=None):
 
     all_codestreams = get_supported_codestreams()
     filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)
+    filtered_codesteams = utils.filter_codestreams_by_arch(archs, filtered_codesteams)
     patched_kernels = get_patched_kernels(filtered_codesteams, patches)
 
     working_cs = []
     patched_cs = []
     unaffected_cs = []
     for cs in filtered_codesteams:
-
-        # Skip codestreams that do not support the given archs.
-        cs.set_archs(archs)
-        if not cs.archs:
-            continue
-
         if cs.kernel in patched_kernels:
             patched_cs.append(cs.full_cs_name())
             continue

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -11,7 +11,7 @@ from klpbuild.klplib import utils
 from klpbuild.klplib import patch
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.data import download_missing_cs_data
-from klpbuild.klplib.ksrc import get_patches, cs_is_affected
+from klpbuild.klplib.ksrc import get_patches
 from klpbuild.klplib.bugzilla import get_pending_bugs, get_bug_data, is_bug_dropped, get_bug_dep
 
 PLUGIN_CMD = "scan"
@@ -233,3 +233,11 @@ def get_patched_kernels(codestreams, patches):
     return kernels
 
 
+def cs_is_affected(cs, cve, patches):
+    # We can only check if the cs is affected or not if the CVE was informed
+    # (so we can get all commits related to that specific CVE). Otherwise we
+    # consider all codestreams as affected.
+    if not cve:
+        return True
+
+    return len(patches[cs.base_cs_name()]) > 0

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -11,7 +11,7 @@ from klpbuild.klplib import utils
 from klpbuild.klplib import patch
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.data import download_missing_cs_data
-from klpbuild.klplib.ksrc import get_patches, get_patched_kernels, cs_is_affected
+from klpbuild.klplib.ksrc import get_patches, cs_is_affected
 from klpbuild.klplib.bugzilla import get_pending_bugs, get_bug_data, is_bug_dropped, get_bug_dep
 
 PLUGIN_CMD = "scan"
@@ -199,3 +199,37 @@ def scan(cve, conf, lp_filter, download, archs=None, savedir=None):
         logging.info("\t%s\n", utils.classify_codestreams_str(working_cs))
 
     return patches, upstream, patched_cs, working_cs
+
+
+def get_patched_kernels(codestreams, patches):
+    if not patches:
+        return []
+
+    logging.info("Searching for already patched codestreams...")
+
+    kernels = set()
+
+    for cs in codestreams:
+        bc = cs.base_cs_name()
+        suse_patches = patches[bc]
+        if not suse_patches:
+            continue
+
+        # Proceed to analyse each codestream's kernel
+        kernel = cs.kernel
+
+        logging.debug("\n%s (%s):", cs.full_cs_name(), kernel)
+        for patch in suse_patches:
+            if not cs.has_patch(patch):
+                # Store the patches required by this codestreams for future use
+                cs.add_required_patch(patch)
+                break
+            logging.debug(patch)
+        else:
+            kernels.add(kernel)
+
+    logging.debug("")
+
+    return kernels
+
+

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -156,7 +156,9 @@ def setup_codestreams(lp_name, data):
                                                     data["archs"],
                                                     utils.get_workdir(lp_name))
 
-    # Add new codestreams to the already existing list, skipping duplicates
+    # Add new codestreams names to the already existing list, skipping
+    # duplicates
+    patched_cs = [cs.full_cs_name() for cs in patched_cs]
     old_patched_cs = get_codestreams_data('patched_cs')
     new_patched_cs = natsorted(list(set(old_patched_cs + patched_cs)))
 

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -59,7 +59,8 @@ def test_find_obj_path_arch():
         "repo": "SUSE_SLE-15-SP5_Update",
         "configs": {
             "CONFIG_NET_SCH_TAPRIO": {"x86_64":"m","ppc64le":"m","s390x":"m"}
-            }
+            },
+        "required_patches" : ""
     })
 
     for arch in ARCHS:


### PR DESCRIPTION
This is an initial reorganization of the code around `scan` and the way we store the patches in preparation for fixing #153 .

The final fix can be implemented only after #160 is merged since that PR drops the use of quilt to apply the patches, which makes it more easy to selectively apply them.

I took the chance to further refactor `scan`. What was done before is:

1. Retrieve the filtered codestreams
2. First loop on them to retrieve the patched kernels (using `get_patched_kernels()`)
3. Second loop on the filtered codestreams to check these whose kernel belong to the list of patched_kernels, otherwise add them either to working_cs or unaffected_cs (or skipping due to missing support for arch)

The unnecessary thing was that we were storing the `cs.kernel` in `patched_kernels` when filtering with `get_patched_kernels()`. And then afterward we were checking which codestreams had that kernel with `if cs.kernel in patched_kernels`. This has been simplified by just filtering the patched codestreams (rather than their kernel). With this, a whole loop has been dropped because unneeded.

Now the process is:

1. Retrieve the filtered codestreams
2. Loop over the filtered codestreams and filter it into affected_cs, unaffected_cs, patched_cs (in the same loop)

Avoiding the unneeded `patched_kernel.add(cs.kernel)` and then `cs` -> `cs.kernel` -> `if cs.kernel in patched_cs` -> `patched_cs.append(cs)` steps.

Besides that, the most notable part is that now the required patches are stored in the codestream object directly, so that we can just retrieve the patches from there on a per codestream basis rather than on a per product basis, effectively introducing the possibility to perform the patch analysis only on those that are needed. And same goes for the extraction where we will be able to apply only the needed ones.

This is yet to be tested. I am posting this PR in advance to help coordinate the work across different PRs.
