### PR TITLE
klplib/ksrc: Blacklist kmp modules

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -367,7 +367,8 @@ def ksrc_is_module_supported(module, kernel):
         kernel (sr): Kernel version.
 
     returns:
-        Return True if supported. False otherwise.
+        Return True if supported and False otherwise.
+        Return True if blacklisted and False otherwise.
         """
     UNSUPPORTED_MARKERS = {
         "-",
@@ -382,10 +383,12 @@ def ksrc_is_module_supported(module, kernel):
     mpath = module
     prev = ""
     idx = 1
+    blacklisted = False
+    supported = True
 
     out = ksrc_read_rpm_file(kernel, "supported.conf").splitlines()
     if not out:
-        return False
+        return False, False
 
     # Try the following path combinations to see if it matches with
     # any rule in the supported.conf:
@@ -394,7 +397,7 @@ def ksrc_is_module_supported(module, kernel):
     #   my/kernel/*
     #   my/*
     while mpath != prev:
-        r = re.compile(rf"^([-+]!?\w*)?\s+{mpath}(?:\s+#.*)?$")
+        r = re.compile(rf"^([-+]!?[\w\-]*)?\s+{mpath}(?:\s+#.*)?$")
         matches = [m for line in out if (m := r.match(line))]
 
         # Try more generic path if we don't match
@@ -411,15 +414,19 @@ def ksrc_is_module_supported(module, kernel):
 
         # Line has matched but there's no marker -> module is supported
         if not markers:
-            return True
+            break
+
+        # Blacklisted, but supported for livepatching.
+        if re.match(r"\+.*-kmp", markers[0]):
+            blacklisted = True
 
         # Check if any marker belongs to UNSUPPORTED_MARKERS
-        if markers[0] in UNSUPPORTED_MARKERS:
-            return False
+        elif markers[0] in UNSUPPORTED_MARKERS:
+            supported = False
 
-        if markers[0] in SUPPORTED_MARKERS:
-            return True
+        elif markers[0] not in SUPPORTED_MARKERS:
+            raise RuntimeError(f"ERROR: {mpath} marker {marker} in {kernel}:supported.conf is not known!")
 
-        raise RuntimeError(f"ERROR: {mpath} marker {marker} in {kernel}:supported.conf is not known!")
+        break
 
-    return True
+    return supported, blacklisted

--- a/klpbuild/klplib/patch.py
+++ b/klpbuild/klplib/patch.py
@@ -5,6 +5,7 @@
 
 import logging
 
+from pathlib import PurePosixPath
 from collections import defaultdict
 
 from klpbuild.klplib import utils
@@ -162,7 +163,11 @@ def analyse_kmodules(cs_list):
                            cs.configs[conf].items()]:
                 continue
 
-            supported = cs.is_module_supported(mod)
+            supported, blacklisted = cs.is_module_supported(mod)
+            if blacklisted:
+                logging.warning("%s: Module '%s' is not supported by klp-build.",
+                                cs.full_cs_name(), PurePosixPath(mod).name)
+
             cs.modules[mod] = supported
             key = f"{mod}:{supported}"
             if cs not in report[key]:

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -35,25 +35,36 @@ def test_get_patch_subject():
 def test_is_module_supported():
     mod = "drivers/net/wireless/ath/ath12k/ath12k"
     # Expected: "- drivers/net/wireless/ath/ath12k/ath12k"
-    assert not ksrc_is_module_supported(mod, "6.4.0-20")
+    supported, _ = ksrc_is_module_supported(mod, "6.4.0-20")
+    assert not supported
     # Expected: "- drivers/net/wireless/*"
-    assert not ksrc_is_module_supported(mod, "4.12.14-122.255")
+    supported, _ = ksrc_is_module_supported(mod, "4.12.14-122.255")
+    assert not supported
 
     mod = "drivers/net/wireless/intersil/prism54/prism54"
     # Expected: "-! drivers/net/wireless/intersil/prism54/prism54"
-    assert not ksrc_is_module_supported(mod, "5.14.21-150400.24.144")
+    supported, _ = ksrc_is_module_supported(mod, "5.14.21-150400.24.144")
+    assert not supported
 
     mod = "drivers/net/wireless/mac80211_hwsim"
     # Expected: "  drivers/net/wireless/mac80211_hwsim"
-    assert ksrc_is_module_supported(mod, "5.14.21-150400.24.144")
+    supported, filtered = ksrc_is_module_supported(mod, "5.14.21-150400.24.144")
+    assert supported and not filtered
 
     mod = "net/tipc/tipc"
     # Expected: "+external	net/tipc/tipc"
-    assert not ksrc_is_module_supported(mod, "6.4.0-150600.23.65")
+    supported, _ = ksrc_is_module_supported(mod, "6.4.0-150600.23.65")
+    assert not supported
 
     mod = "net/netfilter/ipset/ip_set_bitmap_ip"
     # Expected: "+base	net/netfilter/ipset/ip_set_bitmap_ip    # ipset: IP bitmap"
-    assert ksrc_is_module_supported(mod, "6.4.0-10")
+    supported, filtered = ksrc_is_module_supported(mod, "6.4.0-10")
+    assert supported and not filtered
+
+    mod = "fs/gfs2/gfs2"
+    # Expected: "+fs/gfs2/gfs2-kmp"
+    supported, filtered = ksrc_is_module_supported(mod, "6.12.0-160000.5")
+    assert supported and filtered
 
 
 def test_get_rt_patches():


### PR DESCRIPTION
kmp modules are not currently supported by klp-build. If found, trigger a warning to let the user know.