### PR TITLE
New  kgr test path

### DIFF
--- a/scripts/run-kgr-test.sh
+++ b/scripts/run-kgr-test.sh
@@ -34,7 +34,7 @@ if [ ! -f "$TEST_SCRIPT" ]; then
 fi
 
 # Check multiple places where an updated version of the VMs can be found
-for VMSDIR in "$(realpath ../kgr-test/vms)" "$HOME/klp/kgr-test/vms" "$HOME/kgr-test/vms" "$HOME/vms" "/home/nstange/vms"; do
+for VMSDIR in "$(realpath ../kgr-test/vms)" "$HOME/klp/kgr-test/vms" "$HOME/kgr-test/vms" "$HOME/vms" "/home/klp/kgr-test/vms" "/home/nstange/vms"; do
 	if [ -d "$VMSDIR" ]; then
 		echo "Using VMS from $VMSDIR"
 		break
@@ -63,7 +63,7 @@ else
 	JOBS=1
 fi
 
-for KGR_TEST_PATH in "$(realpath ../kgr-test/)" "$HOME/klp/kgr-test/" "/home/nstange/kgr-test"; do
+for KGR_TEST_PATH in "$(realpath ../kgr-test/)" "$HOME/klp/kgr-test/" "/home/klp/kgr-test/" "/home/nstange/kgr-test"; do
 	if [ -d "$KGR_TEST_PATH" ]; then
 		echo "Using kgr-test from $KGR_TEST_PATH"
 		break


### PR DESCRIPTION
Some machines, although not all, have a new 'klp' user which will be the new fallback path for vms data. The end goal is to get rid of other users vms and have a shared directory to save space.