### PR TITLE
extract: fix cleanup regexp

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -264,7 +264,7 @@ def fix_ext_symbols(cs, lp_dat, lp_out):
     for sym_list in lp_dat["ext_symbols"].values():
         for s in sym_list:
             # Keep only static declarations
-            lp_out = re.sub(rf"^(?!static|\s|#).*\s+\(\*klpe_{s}\)[\s\S]*?;",
+            lp_out = re.sub(rf"^(?!static|\s|#)\w[^;:()=]+\(\*klpe_{s}\)[^;:=]*;",
                             '', lp_out, flags=re.MULTILINE)
 
 


### PR DESCRIPTION
Use `^\w` to make sure the match begins with a character.

Then replace `.*` with `[^;:()]` to have a hard guard against label and to make sure we don't overflow after the `;`.

This is just an initial version. If you have ideas to make it more strict I'd appreciate it, I'd rather having this more strict and therefore get some false negative than matching false positive :) 