### PR TITLE
push: always build all archs

### DIFF
--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -101,7 +101,7 @@ def prepare_tests(lp_name, lp_filter):
         logging.info("Checking %s symbols...", arch)
         build_cs = []
         for cs in filter_codestreams(lp_filter, get_codestreams_list()):
-            if arch not in cs.archs:
+            if arch not in cs.get_default_archs():
                 continue
 
             rpm_dir = Path(cs.get_ccp_dir(lp_name), arch, "rpm")

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -45,7 +45,7 @@ def create_prj_meta(cs):
                "<debuginfo><disable/></debuginfo>" + \
                "<repository name=\"standard\">" + \
                f"<path project=\"{cs.get_project_name()}\" repository=\"{cs.get_repo()}\"/>" + \
-               "".join([f"<arch>{arch}</arch>" for arch in cs.archs]) + \
+               "".join([f"<arch>{arch}</arch>" for arch in cs.get_default_archs()]) + \
                "</repository>" + \
            "</project>"
 


### PR DESCRIPTION
We should build all archs even when the livepatch does not affect one of them to make sure that conditional compilation works.