### PR TITLE
klplib: codestream: Handle IBT enabled function offsets

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -417,11 +417,19 @@ class Codestream:
     def __check_patchable_sym(self, arch, name, sym, trace_addrs):
         val = sym["st_value"]
 
-        pos = bisect.bisect_left(trace_addrs, val)
-        if pos == len(trace_addrs) or trace_addrs[pos] != val:
-            logging.error("%s-%s (%s): Symbol %s has tracing disabled.",  self.full_cs_name(),
-                          arch, self.kernel, name)
-            sys.exit(1)
+        # For IBT enabled kernels, some functions might have ENDBR instructions
+        # at the first offset of the symbol. To make the check catch all cases,
+        # always check for the trace addr and also the same trace addr - 4, to
+        # match the symbol table on functions that don't have the IBT enabled.
+        for val in [sym["st_value"], sym["st_value"] + 4]:
+            pos = bisect.bisect_left(trace_addrs, val)
+
+            # Check if the symbol was found
+            if pos != len(trace_addrs) and trace_addrs[pos] == val:
+                return
+
+        logging.error("%s-%s (%s): Symbol %s has tracing disabled.", self.full_cs_name(), arch, self.kernel, name)
+        sys.exit(1)
 
     # On ppc64le the trace_address points to symbol descriptor table, and not
     # the symbol itself, so we need to check for the address range

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -170,3 +170,22 @@ def test_symbol_with_noinstr(caplog):
             setup(**setup_args)
 
     assert "Symbol __ktime_get_real_seconds has tracing disabled." in caplog.text
+
+
+def test_symbol_with_noinstr_ibt(caplog):
+    # IBT enabled kernels can have functions with an offset shifted by 4 bytes
+    # when the funciton has ENDBR instructions. Make sure klp-build handles it
+    # correctly
+    lp = "bsc_" + inspect.currentframe().f_code.co_name
+
+    lp_default_data = {"cve": None, "lp_filter": "16.0rtu1", "conf": "CONFIG_IO_URING", "no_check": True}
+    setup_args = {
+        "lp_name": lp,
+        "archs": ["x86_64"],
+        "module": "vmlinux",
+        "file_funcs": [["io_uring", "io_link_skb"]],
+        "mod_file_funcs": [],
+        "conf_mod_file_funcs": [],
+        **lp_default_data
+    }
+    setup(**setup_args)


### PR DESCRIPTION
When checking if a symbol is traceable, the trace addresses can be 4 bytes ahead of the symbol table. This happens when the symbol has an additional ENDBR instruction, which shifts the __fentry__ by 4 bytes.

In order to correctly identify if a symbol is traceable or not, check both addresses: the one found symbol, and one by shifting the addr by 4 bytes.