### PR TITLE
Fix missing ifdefs when only one architecture is affected

### DIFF
--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -144,6 +144,10 @@ def setup_archs(codestreams):
     archs = utils.affected_archs(codestreams)
     set_codestreams_data(archs=archs)
 
+    # Inspect which codestreams are enabled for the affected architectures
+    for cs in codestreams:
+        cs.archs = (cs.archs & set(utils.affected_archs([cs])))
+
 
 def setup_codestreams(lp_name, data):
     if not lp_name.startswith("bsc"):

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -138,6 +138,36 @@ def test_is_enabled_only_on_cs_arcs():
         assert "#if IS_ENABLED" not in content
 
 
+# Check if only x86_64 is affected by the CVE, meaning that IS_ENABLED should be
+# set in the final code
+def test_is_enabled_only_on_x86():
+    lp = "bsc_" + inspect.currentframe().f_code.co_name
+    cs = "15.7u5"
+
+    setup_args = {
+        "lp_name": lp,
+        "lp_filter": cs,
+        "no_check": True,
+        "archs": utils.ARCHS,
+        "cve": None,
+        "conf": "CONFIG_ACPI",
+        "module": None,
+        "file_funcs": [
+            ["drivers/acpi/acpica/utcopy.c", "acpi_ut_copy_ipackage_to_ipackage"]
+        ],
+        "mod_file_funcs": [],
+        "conf_mod_file_funcs": [],
+        "full_checks": False,
+    }
+    setup(**setup_args)
+
+    extract(lp_name=lp, lp_filter=cs, no_patches=True, avoid_ext=[])
+
+    content = get_file_content(lp, cs, f"livepatch_{lp}.c")
+    # This CVE impact only x86, so IS_ENABLED should be present
+    assert "#if IS_ENABLED" in content
+
+
 # For multifile patches, a third file will be generated and called
 # livepatch_XXX, and alongside this file the other files will have the prefix
 # bscXXXXXXX.


### PR DESCRIPTION
For one livepatch I found that there were missing ifdefs for an ACPI file, which is weird because only x86_64 has CONFIG_ACPI set. This now makes sure that we add ifdefs if the CONFIG_ entries are not the same as cs.get_default_archs().