### PR TITLE
templ: move livepatch header above klp-ccp extracted code

### DIFF
--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -186,9 +186,9 @@ TEMPL_PATCH_VMLINUX = """\
 #if IS_ENABLED(${ config })
 % endif # check_enabled
 
-<%include file="${ inc_src_file }"/>
-
 #include "livepatch_${ lp_name }.h"
+
+<%include file="${ inc_src_file }"/>
 
 % if ext_vars:
 % if ibt:
@@ -229,9 +229,9 @@ TEMPL_PATCH_MODULE = """\
 #endif
 % endif # check_enabled
 
-<%include file="${ inc_src_file }"/>
-
 #include "livepatch_${ lp_name }.h"
+
+<%include file="${ inc_src_file }"/>
 
 % if ext_vars:
 % if ibt:


### PR DESCRIPTION
On sle16 -Werror=missing-prototypes requires the prototype of the klpp_* function. Moving the header before solves the issue.

This is leading to build errors and the CI fails on some LP.