### PR TITLE
data: add arguments --cleanup-obsolete and --update to the command `klp-build data`

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -54,6 +54,13 @@ Download all the missing supported codestreams data.
 .TP
 .B --force
 Re-download also codestream that are not missing.
+.TP
+.B --cleanup-obsolete
+Clean up the obsolete data generated for unsupported code streams.
+.TP
+.B --update
+Download the missing codestreams data and clean up the obsolete data. It has the same result as
+--download and --cleanup-obsolete.
 .RE
 .TP
 .B scan

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -4,10 +4,69 @@
 # Authors: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
 
 import logging
+import shutil
 
-from klpbuild.klplib.utils import classify_codestreams_str
+from klpbuild.klplib.utils import classify_codestreams_str,ARCHS
 from klpbuild.klplib.ibs import download_cs_rpms
+from klpbuild.klplib.config import get_user_path
+from klpbuild.klplib.kernel_tree import  cleanup_obsolete_trees
 
+def filter_obsolete_directories(target_path, valid_kerns):
+    """
+    check the path including the kernel version is valid or not
+    """
+    ret_paths = []
+    
+    if not target_path.exists():
+        return []
+
+    # Iterate through subdirectories/files in the target path
+    for item in target_path.iterdir():
+        item_str = item.name # Use the name of the folder, not the full path string
+
+        # Check if any valid kernel version string exists within this folder name
+        is_valid = any(k in item_str for k in valid_kerns)
+        if not is_valid:
+            ret_paths.append(item)
+
+    return ret_paths
+
+def cleanup_obsolete_data(valid_codestreams):
+    """
+    Remove obsolete rpm packages and extracted sources
+    """
+    obsolete_paths = []
+
+    valid_kerns = [cs.kernel for cs in valid_codestreams]
+    # The paths we going through:
+    # $data_dir/kernel-rpms
+    # $data_dir/$arch/boot/
+    # $data_dir/$arch/lib/modules
+    # $data_dir/$arch/usr/lib/modules
+
+    data_dir = get_user_path("data_dir")
+    for arch in ARCHS:
+        for d in ["boot", "lib/modules", "usr/lib/modules"]:
+            dest_dir = data_dir/arch/d
+            if dest_dir.exists():
+                obsolete_paths.extend(filter_obsolete_directories(dest_dir, valid_kerns))
+    # check the special dir
+    rpm_dir = data_dir/"kernel-rpms"
+    if rpm_dir.exists():
+        obsolete_paths.extend(filter_obsolete_directories(rpm_dir, valid_kerns))
+
+    # do the cleanup
+    for p in obsolete_paths:
+        try:
+            if p.is_dir():
+                shutil.rmtree(p)
+            else:
+                p.unlink() # Delete file if it's an RPM and not a directory
+            logging.info(f"Removed obsolete path: {p}")
+        except Exception as e:
+            logging.error(f"Error removing {p}: {e}")
+
+    cleanup_obsolete_trees(valid_codestreams)
 
 def download_missing_cs_data(codestreams):
     cs_to_download = __get_cs_missing_data(codestreams)

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -234,12 +234,15 @@ def __get_active_worktrees(kernel_tree):
 
 
 def __remove_worktree(kernel_tree, worktree_dir):
-    subprocess.check_output(["/usr/bin/git", "-C", kernel_tree, "worktree",
-                             "remove", worktree_dir, "-f", "-f"],
-                            stderr=subprocess.PIPE)
+    try:
+        subprocess.check_output(["/usr/bin/git", "-C", kernel_tree, "worktree",
+                                 "remove", worktree_dir, "-f", "-f"],
+                                stderr=subprocess.PIPE)
 
-    if os.path.isdir(worktree_dir):
-        shutil.rmtree(worktree_dir)
+        if os.path.isdir(worktree_dir):
+            shutil.rmtree(worktree_dir)
+    except Exception as e:
+        logging.info(f"Error removing {worktree_dir}: {e}")
 
 
 def __prune_worktrees(kernel_tree):

--- a/klpbuild/klplib/kernel_tree.py
+++ b/klpbuild/klplib/kernel_tree.py
@@ -161,6 +161,20 @@ def init_cs_kernel_tree(kernel_version, outdir):
             "add", outdir, "--checkout", kernel_tree_git_tag
         ], stderr=subprocess.PIPE)
 
+def cleanup_obsolete_trees(codestreams):
+    """
+    Remove obsolete kernel source trees.
+    """
+    kernel_tree = get_user_path("kernel_dir")
+    worktrees = __get_active_worktrees(kernel_tree)
+    valid_kerns = [cs.kernel for cs in codestreams]
+
+    for wt in worktrees:
+        wt_str = Path(wt).name # Use the name of the folder, not the full path string
+        is_valid = any(k in wt_str for k in valid_kerns)
+        if not is_valid:
+            logging.info("Removing worktree %s", wt)
+            __remove_worktree(kernel_tree, wt)
 
 def cleanup_kernel_trees():
     """

--- a/klpbuild/plugins/data.py
+++ b/klpbuild/plugins/data.py
@@ -6,7 +6,7 @@
 import logging
 
 from klpbuild.klplib.cmd import add_arg_lp_filter
-from klpbuild.klplib.data import download_missing_cs_data, download_cs_data
+from klpbuild.klplib.data import download_missing_cs_data, download_cs_data, cleanup_obsolete_data
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.utils import filter_codestreams
 
@@ -18,20 +18,26 @@ def register_argparser(subparser):
     )
 
     add_arg_lp_filter(fmt)
-    fmt.add_argument("--download", required=True, action="store_true",
+    fmt.add_argument("--download", required=False, action="store_true",
                      help="Download all the missing supported codestreams data")
     fmt.add_argument("--force",action="store_true",
                      help="Re-download also codestream that are not missing")
+    fmt.add_argument("--cleanup-obsolete", required=False, action="store_true",
+                     help="Cleanup the obsolete files and directories")
+    fmt.add_argument("--update", required=False, action="store_true",
+                     help="Do the job of --download and --cleanup-obsolete")
 
-
-def run(download, force, lp_filter):
+def run(download, force, cleanup_obsolete, update, lp_filter):
     supported_codestreams =  get_supported_codestreams()
     filtered_codestreams = filter_codestreams(lp_filter, supported_codestreams)
 
-    if download:
+    if download or update:
         if force:
             download_cs_data(filtered_codestreams)
         else:
             download_missing_cs_data(filtered_codestreams)
-    else:
-        logging.error("Use --download")
+    if cleanup_obsolete or update:
+        cleanup_obsolete_data(supported_codestreams)
+    if not (download or cleanup_obsolete or update):
+        logging.error("Use --download, --cleanup-obsolete or --update for this command")
+


### PR DESCRIPTION
Added a new option --local to the command `klp-build clean-sources` to cleanup the obsolete rpm packages and the corresponding extracted directories, otherwise I have to expand my VM disk image continuously with new kernel MU is released.