### PR TITLE
templ: fix regexp to find incomplete struct declaration

### DIFF
--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -474,7 +474,7 @@ def __generate_klpp_header(cs):
         protos = list(dat["klpp_symbols"].values())
         funcs.extend(protos)
         for p in protos:
-            m = re.findall(r"(struct\s+\w+)\s*\*?\w+", p)
+            m = re.findall(r"(struct\s+\w+)\s*\**\w+", p)
             if not m:
                 continue
             structs.update(m)


### PR DESCRIPTION
The regexp is broken when there are more than one '*':

Given the input 'struct nlattr **tca', the regexp:

- before this patch matched 'struct nlatt'
- now matches 'struct nlattr'