### PR TITLE
push: enable building conflicting livepatches

### DIFF
--- a/klpbuild/klplib/kgraft.py
+++ b/klpbuild/klplib/kgraft.py
@@ -47,8 +47,9 @@ def fetch_branch(branch, remote="origin"):
 
 def rebase_lp_branch(branch, new_base, remote="origin"):
     new_base = f"{remote}/{new_base}"
+    base_branch = f"{branch}~1"
     subprocess.check_output(
-            ["git", "rebase", new_base, branch],
+            ["git", "rebase", "--onto", new_base, base_branch, branch],
             stderr=subprocess.STDOUT, cwd=get_kgraft()
             )
 


### PR DESCRIPTION
When a livepatch conflicts with a previous one that patches the same affected function, the usual workflow cannot be used.

In this case, the diff is going to be applied directly of top of the previous conflicting bsc directory, rather than creating a new bsc directory for the current bsc.

This means that we cannot use master-livepatch branch as a base to create the bsc directory and then rebase it appropriately on the affected product branches. Instead, for each group, we'd need to work on a product branch so that we have the previous conflicting bsc directory as a base where we can apply the diff and then commit it.

With this patch, it's possible to take that commit and apply it to the others product branches that belongs to the same group before pushing to IBS.

---

My idea is not to have this merged now, but to keep this branch here as a reference when someone will happen to work on a conflicting livepatch and have trouble building. I haven't tested how this change works with normal livepatches.