### PR TITLE
setup: add --add-patches option to specify prerequisite patches

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -189,6 +189,13 @@ will be livepatched instead.
 .TP
 .BI --archs " {ppc64le,s390x,x86_64} [{ppc64le,s390x,x86_64} ...]"
 Supported architectures for this livepatch.
+.TP
+.BI --add-patches " PATCH [PATCH ...]"
+Path(s) of additional patches from kernel-source (e.g.\&
+.IR patches.suse/some-fix.patch ).
+Can specify multiple patches.
+These patches will be checked per-codestream and applied before CVE patches
+when present on the branch.
 .RE
 .TP
 .B extract

--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -224,7 +224,7 @@ def get_branch_patches(cve, mbranch):
 
 
 @__check_kernel_source_tags_are_fetched
-def get_patches(cve, savedir=None):
+def get_patches(cve, savedir=None, extra_patches=[]):
     logging.info("Getting SUSE fixes for upstream commits per CVE branch. It can take some time...")
 
     # Store all patches from each branch
@@ -247,6 +247,20 @@ def get_patches(cve, savedir=None):
         patches[bc] = []
 
         idx = 0
+
+        # Handle extra patches: read them from the branch and store
+        # them before the CVE patches so they get applied first.
+        for extra_patch in extra_patches:
+            pfile = ksrc_read_branch_file(mbranch, extra_patch)
+            if pfile:
+                idx += 1
+                if savedir:
+                    store_patch(pfile, extra_patch, savedir, idx, bc)
+                patches[bc].append(extra_patch)
+                logging.debug("\textra patch %s found in %s", extra_patch, mbranch)
+            else:
+                logging.debug("\textra patch %s not found in %s", extra_patch, mbranch)
+
         for patch in get_branch_patches(cve, mbranch):
             if patch.strip().startswith("#"):
                 continue

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -106,10 +106,10 @@ def scan_job(bug, cve):
     return status, affected_archs, affected
 
 
-def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None):
+def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None, extra_patches=[]):
     assert cve and utils.is_cve_valid(cve)
 
-    upstream, patches = get_patches(cve, savedir)
+    upstream, patches = get_patches(cve, savedir, extra_patches)
 
     all_codestreams = get_supported_codestreams()
     filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -80,14 +80,26 @@ def register_argparser(subparser):
         nargs="+",
         help="Supported architectures for this livepatch",
     )
+    args.add_argument(
+        "--add-patches",
+        type=str,
+        nargs="+",
+        required=False,
+        default=[],
+        help="Path(s) of additional patches from kernel-source (e.g. "
+        "patches.suse/some-fix.patch). Can specify multiple patches. "
+        "These patches will be checked per-codestream and applied "
+        "before CVE patches if missing.",
+    )
 
 
 def run(lp_name, lp_filter, no_check, archs, conf, module, file_funcs,
-        mod_file_funcs, conf_mod_file_funcs, full_checks):
+        mod_file_funcs, conf_mod_file_funcs, full_checks, add_patches=[]):
     codestreams = setup_codestreams(lp_name, {"conf": conf,
                                               "lp_filter": lp_filter,
                                               "no_check": no_check,
-                                              "archs": archs})
+                                              "archs": archs,
+                                              "extra_patches": add_patches})
 
     if conf:
         setup_manual(codestreams, archs, conf, module,
@@ -162,7 +174,8 @@ def setup_codestreams(lp_name, data):
         _, upstream, patched_cs, codestreams = scan(cve, data["conf"],
                                                     data["lp_filter"], True,
                                                     data["archs"],
-                                                    utils.get_workdir(lp_name))
+                                                    utils.get_workdir(lp_name),
+                                                    data.get("extra_patches", []))
 
     # Add new codestreams names to the already existing list, skipping
     # duplicates

--- a/tests/test_ksrc.py
+++ b/tests/test_ksrc.py
@@ -3,7 +3,8 @@
 # Copyright (C) 2021-2025 SUSE
 # Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
 
-from klpbuild.klplib.ksrc import (get_patches_files, ksrc_is_module_supported,
+from klpbuild.klplib.ksrc import (get_patches, get_patches_files,
+                                  ksrc_is_module_supported,
                                   get_branch_patches, get_patch_subject)
 
 def test_get_patches_files():
@@ -74,3 +75,28 @@ def test_get_rt_patches():
             ]
     patches = get_branch_patches("2024-35905", "SUSE-2024-RT")
     assert patches and expected == patches
+
+
+def test_get_patches_with_extra_patches():
+    extra_patch = "patches.suse/net-fix-__dst_negative_advice-race.patch"
+    cve = "2022-48801"
+
+    _, patches = get_patches(cve, extra_patches=[extra_patch])
+
+    # The additional patch should appear before the CVE patch on branches
+    # where it exists
+    sp5_patches = patches["15.5"]
+    assert extra_patch in sp5_patches
+    assert sp5_patches.index(extra_patch) == 0
+
+
+def test_get_patches_with_nonexistent_extra_patches():
+    cve = "2022-48801"
+
+    _, patches_without = get_patches(cve)
+    _, patches_with = get_patches(cve, extra_patches=["patches.suse/does-not-exist.patch"])
+
+    # Non-existent additional patches should be silently skipped, so the
+    # patch lists must be identical
+    for bc in patches_without:
+        assert patches_without[bc] == patches_with[bc]

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -11,3 +11,13 @@ def test_scan_all_cs_patched(caplog):
     scan("2022-48801", "", "", False)
 
     assert "All supported codestreams are already patched" in caplog.text
+
+
+def test_scan_with_extra_patches(caplog):
+    extra_patch = "patches.suse/net-fix-__dst_negative_advice-race.patch"
+    patches, _, _, _ = scan("2022-48801", "", "", False,
+                            extra_patches=[extra_patch])
+
+    # The additional patch should be included in the patch lists for
+    # branches where it exists
+    assert extra_patch in patches["15.5"]


### PR DESCRIPTION
It happens often that the extract command fails to apply the backports on the kernel sources. This usually happens because there are missing patches that needs to be pulled in and applied to the source before the backports to prepare the code context. This PR introduces the `--prereq` option to instruct klp-build to grab more patches and apply them before the backports.