### PR TITLE
Check livepatch EOL

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -20,10 +20,10 @@ from klpbuild.klplib.ksrc import KERNEL_BRANCHES
 
 class Codestream:
     __slots__ = ("__name", "sle", "sp", "update", "rt", "is_micro", "is_slfo",
-                 "__project", "patchid", "kernel", "archs", "files", "modules",
-                 "repo", "configs", "required_patches")
+                 "__project", "patchid", "kernel", "eol", "archs", "files",
+                 "modules", "repo", "configs", "required_patches")
 
-    def __init__(self, name, project="", patchid="", kernel="",
+    def __init__(self, name, project="", patchid="", kernel="", eol="",
                  archs=None, files=None, modules=None, configs=None,
                  required_patches=None):
 
@@ -45,6 +45,7 @@ class Codestream:
         self.__project = project
         self.patchid = patchid
         self.kernel = kernel
+        self.eol = eol
 
         self.archs = set(archs) if archs is not None else self.get_default_archs()
         self.files = files if files is not None else {}
@@ -56,8 +57,8 @@ class Codestream:
 
     @classmethod
     def from_data(cls, data):
-        return cls(data["name"],data["project"], data["patchid"],
-                   data["kernel"], data["archs"], data["files"],
+        return cls(data["name"], data["project"], data["patchid"],
+                   data["kernel"], data["eol"], data["archs"], data["files"],
                    data["modules"], data["configs"], data["required_patches"])
 
     def to_data(self):
@@ -67,6 +68,7 @@ class Codestream:
                 "project": self.__project,
                 "patchid": self.patchid,
                 "kernel" : self.kernel,
+                "eol" : self.eol,
                 "archs": list(self.archs),
                 "files" : self.files,
                 "modules" : self.modules,

--- a/klpbuild/klplib/supported.py
+++ b/klpbuild/klplib/supported.py
@@ -59,10 +59,9 @@ def __get_supported_codestreams():
     lines = __download_supported_file() if not utils.in_test_mode() else __load_supported_file()
 
     for line in lines:
-        # remove the last two columns, which are dates of the line
-        # and add a fifth field with the forth one + rpm- prefix, and
-        # remove the build counter number
-        full_cs, proj, kernel_full, _, _ = line.split(",")
+        full_cs, proj, kernel_full, eol, eol_ltss = line.split(",")
+        if eol_ltss.strip():
+            eol = eol_ltss
 
         kernel = re.sub(r"\.\d+$", "", kernel_full)
 
@@ -71,14 +70,14 @@ def __get_supported_codestreams():
         if "/" in proj:
             proj, patchid = proj.split("/")
 
-        cs = __codestream_from_supported(full_cs, proj, patchid, kernel)
+        cs = __codestream_from_supported(full_cs, proj, patchid, kernel, eol)
         __supported_codestreams_cache.append(cs)
 
     __supported_codestreams_fetched = True
     return copy.deepcopy(__supported_codestreams_cache)
 
 
-def __codestream_from_supported(cs, proj, patchid, kernel):
+def __codestream_from_supported(cs, proj, patchid, kernel, eol):
     # Parse SLE15-SP2_Update_25 to 15.2u25
     rt = "rt" if "-RT" in cs else ""
     sp = "0"
@@ -98,7 +97,7 @@ def __codestream_from_supported(cs, proj, patchid, kernel):
         assert False, "codestream name should contain either SLE or MICRO!"
 
     cs_name = f"{sle}.{sp}{rt}u{update}"
-    return Codestream(cs_name, proj, patchid, kernel)
+    return Codestream(cs_name, proj, patchid, kernel, eol)
 
 
 def __load_supported_file():

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -6,6 +6,7 @@
 import io
 import logging
 import os
+from datetime import date, timedelta
 from pathlib import Path
 import platform
 import re
@@ -448,3 +449,30 @@ def in_test_mode():
 def is_cve_valid(cve):
     # Support CVEs from 2020 up to 2029
     return re.match(r"^202[0-9]-[0-9]{4,7}$", cve)
+
+
+def get_lp_eol(cs_list):
+    '''
+    Return the latest EOL date across all codestreams in the list.
+
+    Args:
+        cs_list (list[Codestream]): List of codestreams.
+
+    Returns:
+        str: The latest EOL date string (YYYY-MM-DD).
+    '''
+    return max(cs.eol for cs in cs_list)
+
+
+def is_lp_eol_soon(cs_list):
+    '''
+    Check if the livepatch EOL is within 30 days.
+
+    Args:
+        cs_list (list[Codestream]): List of codestreams.
+
+    Returns:
+        bool: True if the latest EOL is within 30 days from today.
+    '''
+    eol = date.fromisoformat(get_lp_eol(cs_list))
+    return eol <= date.today() + timedelta(days=30)

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -103,7 +103,7 @@ def scan_job(bug, cve):
     # All = ppc64le, s390x and x86_64
     # None = klp-build failed to determine the CONFIGs.
     if (archs := utils.affected_archs(affected_cs)):
-        affected_archs = "All" if archs == utils.ARCHS else ','.join(archs)
+        affected_archs = "All" if set(archs) == utils.ARCHS else ','.join(archs)
 
     return status, affected_archs, eol, affected
 

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -73,13 +73,14 @@ def scan_bugzilla():
     logging.getLogger().setLevel(logging.INFO)
 
     logging.info(tabulate.tabulate(table, headers=["ID", "CVE", "SUBSYSTEM", "CVSS", "PRIORITY",
-                                                   "STATUS", "ARCHS", "AFFECTED"]))
+                                                   "STATUS", "ARCHS", "EOL", "AFFECTED"]))
 
 
 def scan_job(bug, cve):
     affected = "No"
     status = "Not-Fixed"
     affected_archs = "None"
+    eol = "n/a"
 
     patches, _, _, affected_cs = scan(cve, None, None, False)
 
@@ -97,13 +98,14 @@ def scan_job(bug, cve):
 
     if affected_cs:
         affected = utils.classify_codestreams_str(affected_cs)
+        eol = utils.get_lp_eol(affected_cs)
 
     # All = ppc64le, s390x and x86_64
     # None = klp-build failed to determine the CONFIGs.
     if (archs := utils.affected_archs(affected_cs)):
         affected_archs = "All" if archs == utils.ARCHS else ','.join(archs)
 
-    return status, affected_archs, affected
+    return status, affected_archs, eol, affected
 
 
 def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None, extra_patches=[]):
@@ -179,6 +181,9 @@ def scan(cve, conf, lp_filter, download, archs=utils.ARCHS, savedir=None, extra_
     else:
         logging.info("All affected codestreams:")
         logging.info("\t%s\n", utils.classify_codestreams_str(affected_cs))
+        if utils.is_lp_eol_soon(affected_cs):
+            logging.warning("The livepatch EOL will be soon (%s).\n",
+                            utils.get_lp_eol(affected_cs))
 
     return patches, upstream, patched_cs, affected_cs
 

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -23,6 +23,7 @@ def test_find_obj_path_arch():
         "project": "SUSE:Maintenance:34200",
         "patchid": "",
         "kernel": "5.14.21-150500.55.68",
+        "eol": "2025-11-09",
         "archs": [
             "x86_64",
             "s390x",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -298,3 +298,57 @@ def test_get_lp_groups_mixed(tmp_path, monkeypatch):
         "15.7rtu6-8": [Codestream("15.7rtu6"), Codestream("15.7rtu7"), Codestream("15.7rtu8")],
         "6.0u0-2":    [Codestream("6.0u0"), Codestream("6.0u1"), Codestream("6.0u2")],
     }
+
+
+def test_get_lp_eol():
+    cs_list = [
+        Codestream("15.5u20", eol="2025-11-09"),
+        Codestream("15.5u21", eol="2026-01-17"),
+        Codestream("15.5u22", eol="2026-02-21"),
+    ]
+    assert utils.get_lp_eol(cs_list) == "2026-02-21"
+
+
+def test_get_lp_eol_single():
+    cs_list = [Codestream("15.6u5", eol="2025-11-09")]
+    assert utils.get_lp_eol(cs_list) == "2025-11-09"
+
+
+def test_is_lp_eol_soon():
+    from datetime import date, timedelta
+
+    today = date.today()
+
+    # EOL in the past
+    past = (today - timedelta(days=1)).isoformat()
+    assert utils.is_lp_eol_soon([Codestream("15.5u20", eol=past)])
+
+    # EOL is today
+    assert utils.is_lp_eol_soon([Codestream("15.5u20", eol=today.isoformat())])
+
+    # EOL in 29 days
+    soon = (today + timedelta(days=29)).isoformat()
+    assert utils.is_lp_eol_soon([Codestream("15.5u20", eol=soon)])
+
+    # EOL in exactly 30 days
+    edge = (today + timedelta(days=30)).isoformat()
+    assert utils.is_lp_eol_soon([Codestream("15.5u20", eol=edge)])
+
+    # EOL in 31 days
+    far = (today + timedelta(days=31)).isoformat()
+    assert not utils.is_lp_eol_soon([Codestream("15.5u20", eol=far)])
+
+
+def test_is_lp_eol_soon_uses_latest():
+    from datetime import date, timedelta
+
+    today = date.today()
+    past = (today - timedelta(days=10)).isoformat()
+    far = (today + timedelta(days=60)).isoformat()
+
+    # One CS expired, but the latest EOL is far out
+    cs_list = [
+        Codestream("15.5u20", eol=past),
+        Codestream("15.5u21", eol=far),
+    ]
+    assert not utils.is_lp_eol_soon(cs_list)


### PR DESCRIPTION
Print the livepatch EOL (End Of Life) during `scan` and warn if all the affected codestreams will become unsupported in less than 30 days. In such case, the developer might choose to skip working on this CVE.