### PR TITLE
Improve bsc validation

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -239,7 +239,7 @@ class Codestream:
         Returns:
             Path: The path to the ccp directory of the current codestream.
         """
-        return get_workdir(lp_name)/"ccp"/self.full_cs_name()
+        return get_workdir(lp_name, True) / "ccp" / self.full_cs_name()
 
 
     def get_lp_dir(self, lp_name):

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -386,17 +386,29 @@ def get_fname(src_name):
     return str(Path(src_name).with_suffix("")).replace("-", "_")
 
 
-def get_workdir(lp_name):
+def get_workdir(lp_name, check=False):
     """
-    Get the working directory for a given livepatch name.
+    Get the working directory for a given livepatch name, and optionally check
+    if the livepatch directory exists.
 
     Args:
         lp_name (str): The name of the livepatch.
+        check (bool): Verify if the workdir exists
 
     Returns:
-        Path: The full path to the livepatch file.
+        Path: The full path to the livepatch project directory.
+        ValueError: If the check argument was True and the workdir doesn't exists
+        RuntimeError: If the lp_name doesn't comply with validate_lp_name
+
     """
-    return get_user_path('work_dir')/lp_name
+
+    validate_lp_name(lp_name)
+
+    wdir = get_user_path("work_dir") / lp_name
+    if check and not wdir.exists():
+        raise ValueError(f"Project {wdir} doesn't exists")
+
+    return wdir
 
 
 def get_datadir(arch=""):

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -476,3 +476,8 @@ def is_lp_eol_soon(cs_list):
     '''
     eol = date.fromisoformat(get_lp_eol(cs_list))
     return eol <= date.today() + timedelta(days=30)
+
+
+def validate_lp_name(lp_name):
+    if not lp_name.startswith("bsc"):
+        raise ValueError("Please use prefix 'bsc' for livepatch name")

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -804,10 +804,7 @@ def extract(lp_name, lp_filter, no_patches, avoid_ext):
 
 
 def start_extract(lp_name, lp_filter, no_patches, avoid_ext):
-    if not utils.get_workdir(lp_name).exists():
-        raise ValueError(f"{utils.get_workdir(lp_name)} not created. Run the setup subcommand first")
-
-    logging.info("Work directory: %s", utils.get_workdir(lp_name))
+    logging.info("Work directory: %s", utils.get_workdir(lp_name, True))
 
     working_cs = utils.filter_codestreams(lp_filter, get_codestreams_list(), verbose=True)
 

--- a/klpbuild/plugins/format_patches.py
+++ b/klpbuild/plugins/format_patches.py
@@ -33,7 +33,7 @@ def run(lp_name, no_test, version):
     kgr_patches = get_user_path('kgr_patches_dir')
 
     # Remove dir to avoid leftover patches with different names
-    patches_dir = utils.get_workdir(lp_name)/"patches"
+    patches_dir = utils.get_workdir(lp_name, True) / "patches"
     shutil.rmtree(patches_dir, ignore_errors=True)
 
     prefix = f"Klp-patches][PATCH {ver}"

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -84,12 +84,13 @@ def prepare_tests(lp_name, lp_filter):
     # Download all built rpms
     download_built_rpms(lp_name, lp_filter)
 
+    tests_dir = get_workdir(lp_name, True) / "tests"
     run_test = importlib.resources.files("scripts") / "run-kgr-test.sh"
 
     logging.info("Validating the downloaded RPMs...")
 
     for arch in ARCHS:
-        tests_path = get_workdir(lp_name)/"tests"/arch
+        tests_path = tests_dir / arch
         test_arch_path = tests_path/lp_name
 
         # Remove previously created directory and archive

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -77,7 +77,7 @@ def download_built_rpms(lp_name, lp_filter):
 
 def prepare_tests(lp_name, lp_filter):
     test_src = get_tests_path(lp_name)
-    if not os.access(test_src, os.X_OK):
+    if test_src and not os.access(test_src, os.X_OK):
         logging.error("Script %s has no execution bit set. Aborting", test_src)
         sys.exit(1)
 

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -160,8 +160,7 @@ def setup_archs(codestreams):
 
 
 def setup_codestreams(lp_name, data):
-    if not lp_name.startswith("bsc"):
-        raise ValueError("Please use prefix 'bsc' when creating a livepatch for codestreams")
+    utils.validate_lp_name(lp_name)
 
     cve = None
 


### PR DESCRIPTION
The new checks help us to detect whenever a developer writes the bsc name with a typo in later stages of the livepatch preparation, like format-patches, extraction or prepare-patches.