### PR TITLE
extract: Handle new IPA-removed symbol warning 

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -694,6 +694,34 @@ def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
     return ccp_args, env
 
 
+def _warn_optimized_clone(match, cs, fname):
+    opt_symbol_name = match.group(1)
+    symbol_name = opt_symbol_name.split(".")[0]
+    logging.warning("%s:%s: Symbol %s contains optimized clone: %s",
+                    cs.full_cs_name(), fname, symbol_name, opt_symbol_name)
+    logging.warning("Make sure to patch all the callers of %s.", symbol_name)
+
+
+def _collect_dup_symbol(match, cs, fname):
+    cs.files[fname].setdefault("dup_symbols", [])
+    cs.files[fname]["dup_symbols"].append(match.group(1))
+
+
+CCP_WARNING_SPECS = [
+    (r'warning: optimized function "([^"]+)" in callgraph', _warn_optimized_clone),
+    (r'conflicting definitions for symbol "([\w_]+)" found in ELF', _collect_dup_symbol),
+]
+
+
+def parse_ccp_warnings(f, start_pos, cs, fname):
+    f.seek(start_pos)
+    for line in f:
+        for pattern, handler in CCP_WARNING_SPECS:
+            match = re.search(pattern, line)
+            if match:
+                handler(match, cs, fname)
+
+
 def process(lp_name, total, args, avoid_ext):
     i, make_lock, fname, cs, fdata = args
 
@@ -740,24 +768,7 @@ def process(lp_name, total, args, avoid_ext):
         except Exception as exc:
             raise RuntimeError(f"Error when processing {cs.full_cs_name()}:{fname}. Check file {out_log} for details.") from exc
 
-        # Look for optimized function warnings in the output of the command
-        f.seek(start_pos)
-        symbol_pattern = r'warning: optimized function "([^"]+)" in callgraph'
-        for line in f:
-            match = re.search(symbol_pattern, line)
-            if match:
-                opt_symbol_name = match.group(1)
-                symbol_name = opt_symbol_name.split(".")[0]
-                logging.warning("%s:%s: Symbol %s contains optimized clone: %s",
-                                cs.full_cs_name(), fname, symbol_name, opt_symbol_name)
-                logging.warning("Make sure to patch all the callers of %s.", symbol_name)
-
-    # Look for conflicting/duplicated symbols
-    with open(out_log) as f:
-        msg_pat = r'conflicting definitions for symbol "([\w_]+)" found in ELF'
-        syms = re.findall(msg_pat, f.read())
-        if len(syms) > 0:
-            cs.files[fname]["dup_symbols"] = syms
+        parse_ccp_warnings(f, start_pos, cs, fname)
 
     lp_out = Path(out_dir, cs.lp_out_file(lp_name, fname))
 

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -702,6 +702,13 @@ def _warn_optimized_clone(match, cs, fname):
     logging.warning("Make sure to patch all the callers of %s.", symbol_name)
 
 
+def _warn_ipa_removed(match, cs, fname):
+    symbol_name = match.group(1)
+    logging.warning("%s:%s: Unable to verify if %s symbol is inlined or not."
+                    " Please check manually.",
+                    cs.full_cs_name(), fname, symbol_name)
+
+
 def _collect_dup_symbol(match, cs, fname):
     cs.files[fname].setdefault("dup_symbols", [])
     cs.files[fname]["dup_symbols"].append(match.group(1))
@@ -709,6 +716,7 @@ def _collect_dup_symbol(match, cs, fname):
 
 CCP_WARNING_SPECS = [
     (r'warning: optimized function "([^"]+)" in callgraph', _warn_optimized_clone),
+    (r'warning: "([^"]+)" symbol found in ELF but IPA says removed', _warn_ipa_removed),
     (r'conflicting definitions for symbol "([\w_]+)" found in ELF', _collect_dup_symbol),
 ]
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -19,8 +19,10 @@ from klpbuild.plugins.extract import (
     get_ext_symbols,
     get_klpp_symbols,
     lp_out_cleanup,
+    parse_ccp_warnings,
 )
 from klpbuild.plugins.setup import run as setup
+from tests.utils import FakeCS
 
 
 def test_get_klpp_symbols_missing_patched_funcs(tmp_path):
@@ -470,3 +472,122 @@ def test_lp_out_cleanup_collapses_multiple_empty_lines(tmp_path):
     lp_out = _make_lp_out(tmp_path, "line1\n\n\n\nline2\n")
     lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
     assert "\n\n\n" not in lp_out.read_text()
+
+
+# ── parse_ccp_warnings ─────────────────────────────────────────────────────────
+
+def test_parse_ccp_warnings_optimized_clone(tmp_path, caplog):
+    """Optimized-clone warning logs the clone name and a follow-up reminder."""
+    fname = "net/bluetooth/l2cap_sock.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write('warning: optimized function "l2cap_sock_kill.cold" in callgraph\n')
+
+        with caplog.at_level(logging.WARNING):
+            parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert "Symbol l2cap_sock_kill contains optimized clone: l2cap_sock_kill.cold" in caplog.text
+    assert "Make sure to patch all the callers of l2cap_sock_kill." in caplog.text
+
+
+def test_parse_ccp_warnings_ipa_removed(tmp_path, caplog):
+    """IPA-removed warning logs the symbol name."""
+    fname = "kernel/sched/core.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write('warning: "rcu_read_lock_held" symbol found in ELF but IPA says removed\n')
+
+        with caplog.at_level(logging.WARNING):
+            parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert "Unable to verify if rcu_read_lock_held symbol is inlined or not. Please check manually." in caplog.text
+
+
+def test_parse_ccp_warnings_dup_symbol(tmp_path):
+    """Conflicting-definition line appends the symbol to cs.files[fname]['dup_symbols']."""
+    fname = "net/ipv4/tcp_input.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write('conflicting definitions for symbol "sk_filter_trim_cap" found in ELF\n')
+        parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert cs.files[fname]["dup_symbols"] == ["sk_filter_trim_cap"]
+
+
+def test_parse_ccp_warnings_no_warnings(tmp_path, caplog):
+    """Non-matching lines produce no log output and no side effects."""
+    fname = "fs/ext4/inode.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write("info: everything is fine\n")
+        f.write("note: nothing to see here\n")
+
+        with caplog.at_level(logging.WARNING):
+            parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert caplog.text == ""
+    assert "dup_symbols" not in cs.files[fname]
+
+
+def test_parse_ccp_warnings_multiple_types(tmp_path, caplog):
+    """All three warning types in the same file are each handled."""
+    fname = "net/core/sock.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write('warning: optimized function "tcp_v4_connect.isra.0" in callgraph\n')
+        f.write('warning: "lockdep_rtnl_is_held" symbol found in ELF but IPA says removed\n')
+        f.write('conflicting definitions for symbol "nf_conntrack_in" found in ELF\n')
+        f.write("unrelated output line\n")
+
+        with caplog.at_level(logging.WARNING):
+            parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert "Symbol tcp_v4_connect contains optimized clone: tcp_v4_connect.isra.0" in caplog.text
+    assert "Unable to verify if lockdep_rtnl_is_held symbol is inlined or not. Please check manually." in caplog.text
+    assert cs.files[fname]["dup_symbols"] == ["nf_conntrack_in"]
+
+
+def test_parse_ccp_warnings_respects_start_pos(tmp_path):
+    """Lines written before start_pos are not parsed."""
+    fname = "drivers/scsi/sd.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        # Write a dup-symbol line BEFORE start_pos — must be ignored
+        f.write('conflicting definitions for symbol "sd_probe" found in ELF\n')
+        start_pos = f.tell()
+        f.write('conflicting definitions for symbol "sd_open" found in ELF\n')
+        parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert cs.files[fname]["dup_symbols"] == ["sd_open"]
+
+
+def test_parse_ccp_warnings_multiple_dup_symbols(tmp_path):
+    """Multiple conflicting-definition lines all append to dup_symbols."""
+    fname = "mm/slub.c"
+    cs = FakeCS({fname: {}})
+    log = tmp_path / "ccp.out.txt"
+
+    with open(log, "w+") as f:
+        start_pos = f.tell()
+        f.write('conflicting definitions for symbol "kmem_cache_alloc" found in ELF\n')
+        f.write('conflicting definitions for symbol "kmem_cache_free" found in ELF\n')
+        parse_ccp_warnings(f, start_pos, cs, fname)
+
+    assert cs.files[fname]["dup_symbols"] == ["kmem_cache_alloc", "kmem_cache_free"]

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -12,25 +12,9 @@ from klpbuild.klplib import utils
 from klpbuild.klplib.templ import get_multi_funcs
 from klpbuild.plugins.extract import extract
 from klpbuild.plugins.setup import run as setup
-from tests.utils import get_codestreams_file, get_file_content
+from tests.utils import FakeCS, get_codestreams_file, get_file_content
 
 _generate_klpp_header = templ_module.__dict__["__generate_klpp_header"]
-
-
-class FakeCS:
-    def __init__(self, files, ibt=False, mods=None):
-        self.files = files
-        self._ibt = ibt
-        self._mods = mods or {}
-
-    def needs_ibt(self):
-        return self._ibt
-
-    def lp_out_file(self, lp, f):
-        return f"{lp}_{f.replace('/', '_').replace('-', '_')}"
-
-    def get_file_mod(self, f):
-        return self._mods.get(f, "vmlinux")
 
 
 def test_templ_with_externalized_vars():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,6 +9,26 @@ import json
 from klpbuild.klplib.utils import get_workdir
 
 
+class FakeCS:
+    def __init__(self, files, cs_name="15.4u0", ibt=False, mods=None):
+        self.files = files
+        self._cs_name = cs_name
+        self._ibt = ibt
+        self._mods = mods or {}
+
+    def full_cs_name(self):
+        return self._cs_name
+
+    def needs_ibt(self):
+        return self._ibt
+
+    def lp_out_file(self, lp, f):
+        return f"{lp}_{f.replace('/', '_').replace('-', '_')}"
+
+    def get_file_mod(self, f):
+        return self._mods.get(f, "vmlinux")
+
+
 def get_file_content(lp_name, lp_filter, fname=None):
     # Check the generated LP files
     path = get_workdir(lp_name)/"ccp"/lp_filter/"lp"


### PR DESCRIPTION
klp-ccp now warns when a symbol is found in the ELF but not in the IPA. Catch the warning and print a more sane
log for the klp-build user.

Slightly refactor the extract code to avoid redundant parsing of klp-ccp.out.txt. Add tests covering the new changes.
 