### PR TITLE
templ: relax __is_check_enabled to improve codestreams grouping

### DIFF
--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -13,7 +13,7 @@ from klpbuild.klplib.bugzilla import get_bug_title, get_bug
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.codestreams_data import get_codestreams_data
 from klpbuild.klplib.utils import (fix_mod_string, get_mail, get_workdir,
-                                   get_lp_number, get_fname, is_mod)
+                                   get_lp_number, get_fname, is_mod, ARCHS)
 
 
 MACRO_PROTO_SYMS = """\
@@ -641,8 +641,8 @@ def generate_livepatches(lp_name, cs):
 
 def __is_check_enabled(cs: Codestream):
     # Require the IS_ENABLED ifdef guard whenever we have a livepatch that
-    # is not enabled on all architectures of the given Codestream
-    return cs.archs != cs.get_default_archs()
+    # is not enabled on all supported architectures
+    return cs.archs != ARCHS
 
 
 def __create_kbuild(lp_name, cs):

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -116,8 +116,9 @@ def test_templ_without_externalized_vars():
     assert "IS_ENABLED" not in header
 
 
-# Check that IS_ENABLED macro is set only when the affected architectures of a
-# CVE is not all architectures supported by the given codestream.
+# Check that IS_ENABLED macro is set when the affected architectures of a CVE
+# do not cover all globally supported architectures (even if they cover all
+# architectures of the given codestream).
 def test_is_enabled_only_on_cs_arcs():
     lp = "bsc_" + inspect.currentframe().f_code.co_name
     cs = "6.0u5"
@@ -147,9 +148,10 @@ def test_is_enabled_only_on_cs_arcs():
         "bsc_test_is_enabled_only_on_cs_arcs_net_ipv6_route.c",
     ]:
         content = get_file_content(lp, cs, src)
-        # The given CVE affects all archs in all codestreams, meaning that IS_ENABLED
-        # should not be set.
-        assert "#if IS_ENABLED" not in content
+        # The given CVE affects all archs supported by the MICRO codestream, but
+        # since it doesn't cover all globally supported architectures, IS_ENABLED
+        # should be set.
+        assert "#if IS_ENABLED" in content
 
 
 # Check if only x86_64 is affected by the CVE, meaning that IS_ENABLED should be


### PR DESCRIPTION
If there's a CVE that affects only x86_64, then the #ifdef will be emitted on -default codestreams (cs.archs != cs.get_default_archs()) but not on -rt (in this case cs.archs == cs.get_default_archs()). Therefore the different #ifdef emission decision across codestreams will split the grouping even more.