### PR TITLE
tox: pass KLP_CCP_PYTHONPOLICY_PATH into tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 3.28.0
 log_level = DEBUG
 
 [testenv:{py311,py312}-tests,tests]
-passenv = SSH_AUTH_SOCK
+passenv = SSH_AUTH_SOCK,KLP_CCP_PYTHONPOLICY_PATH
 setenv = TEST_MODE = y
 description = run tests
 deps =


### PR DESCRIPTION
I needed it when using a klp-ccp version not installed in the PATH, but might be worth merging this anyway in case can be useful to you too