### PR TITLE
Do not extract vmlinux and kernel modules

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: zypper in -y python3-devel git python3-pytest tox
+      run: zypper in -y python3-devel git python3-pytest tox python3-magic
 
     - name: Run pylint
       run: >

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -145,19 +145,46 @@ class Codestream:
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             return result.stdout
 
-
-    def get_boot_file(self, file, arch=None):
-        assert file.startswith("vmlinux") or file.startswith("config") or file.startswith("symvers")
-
+    def get_boot_dir(self, arch=None):
+        """
+        Return the directory containing the boot files for the current
+        codestream.
+        """
         if not arch:
             arch = preferred_arch([self])
 
         if self.is_slfo:
-            return Path(self.get_mod_path(arch), file)
+            return self.get_mod_path(arch)
 
-        # Strip the suffix from the filename so we can add the kernel version in the middle
-        fname = f"{Path(file).stem}-{self.get_full_kernel_name()}{Path(file).suffix}"
-        return get_datadir(arch)/"boot"/fname
+        return get_datadir(arch) / "boot"
+
+    def get_boot_filename(self, file):
+        """
+        Files like vmlinux, config and symvers can have different names
+        depending which codestream there are. Return the expected names of the
+        files in the current codestream.
+
+        On SLFO, the filename are don't contain any suffixes, like kernel
+        versions, because they live inside usr/lib/modules directory. For
+        older codestreams we need to append the current kernel version to the
+        file, because all config, symvers and vmlinux live in the same /boot
+        directory.
+        """
+
+        if self.is_slfo:
+            return file
+
+        return f"{file}-{self.get_full_kernel_name()}"
+
+    def get_boot_file(self, file, arch=None):
+        assert file.startswith("vmlinux") or file.startswith("symvers")
+
+        mod_path = self.get_boot_dir(arch)
+
+        if not self.is_slfo:
+            file = f"{file}-{self.get_full_kernel_name()}"
+
+        return mod_path / file
 
     def get_repo(self):
         if self.update == 0 or self.is_slfo:
@@ -403,20 +430,26 @@ class Codestream:
 
         # Module name use underscores, but the final module object uses hyphens.
         mod = mod.replace("_", "[-_]")
-
         mod_path = self.get_mod_path(arch)
-        with open(Path(mod_path, "modules.order")) as f:
-            obj_match = re.search(rf"([\w\/\-]+\/{mod}\.k?o)", f.read())
-            if not obj_match:
-                raise RuntimeError(f"{self.full_cs_name()}-{arch} ({self.kernel}): Module not found: {mod}")
 
-        # modules.order will show the module with suffix .o, so make sure the extension.
-        obj_path = mod_path/(PurePath(obj_match.group(1)).with_suffix(".ko"))
-        # Make sure that the .ko file exists
-        assert obj_path.exists(), f"Module {str(obj_path)} doesn't exists. Aborting"
+        # If the setup subcommand was informing the module, here the module
+        # name will only contain the name, otherwise it will contain the path
+        # to the module.
+        if "/" in mod:
+            with open(Path(mod_path, "modules.order")) as f:
+                obj_match = re.search(rf"([\w\/\-]+\/{mod})\.ko", f.read())
+                if not obj_match:
+                    raise RuntimeError(f"{self.full_cs_name()}-{arch} ({self.kernel}): Module not found: {mod}")
 
-        return obj_path.relative_to(get_datadir(arch))
+            fpath = Path(obj_match.group(1))
+        else:
+            fpath = mod
 
+        fmod = f"{Path(mod_path, fpath)}.ko"
+
+        assert fmod.exists(), f"Module {str(fmod)} doesn't exists. Aborting"
+
+        return fmod.relative_to(get_datadir(arch))
 
     def lp_out_file(self, lp_name, fname):
         fpath = f'{str(fname).replace("/", "_").replace("-", "_")}'
@@ -484,7 +517,7 @@ class Codestream:
     def __check_symbol(self, arch, mod, symbols, check_patchable):
         ret = []
 
-        obj = get_datadir(arch)/self.find_obj_path(arch, mod)
+        obj = get_datadir(arch) / self.find_obj_path(arch, mod)
         elf_obj = get_elf_object(obj)
 
         trace_addrs = []

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -176,16 +176,6 @@ class Codestream:
 
         return f"{file}-{self.get_full_kernel_name()}"
 
-    def get_boot_file(self, file, arch=None):
-        assert file.startswith("vmlinux") or file.startswith("symvers")
-
-        mod_path = self.get_boot_dir(arch)
-
-        if not self.is_slfo:
-            file = f"{file}-{self.get_full_kernel_name()}"
-
-        return mod_path / file
-
     def get_repo(self):
         if self.update == 0 or self.is_slfo:
             return "standard"

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -390,16 +390,16 @@ class Codestream:
         return configs
 
     def find_obj_path(self, arch, mod):
+        # We already know the path to vmlinux, so return it
+        if not is_mod(mod):
+            return self.get_boot_file("vmlinux", arch).relative_to(get_datadir(arch))
+
         # Return the path if the modules was previously found for ARCH, or refetch if
         # the obejct is for a different architecture
         obj = self.modules.get(mod, "")
         if obj:
             assert self.kernel in str(obj)
             return obj
-
-        # We already know the path to vmlinux, so return it
-        if not is_mod(mod):
-            return self.get_boot_file("vmlinux", arch).relative_to(get_datadir(arch))
 
         # Module name use underscores, but the final module object uses hyphens.
         mod = mod.replace("_", "[-_]")

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -333,7 +333,10 @@ class Codestream:
     def is_mod_mutex(self):
         return not self.is_slfo and (self.sle < 15 or (self.sle == 15 and self.sp < 4))
 
-    def get_mod_path(self, arch):
+    def get_mod_path(self, arch=None):
+        if not arch:
+            arch = preferred_arch([self])
+
         # Micro already has support for usrmerge
         if self.is_slfo:
             mod_path = Path("usr", "lib")

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -416,36 +416,60 @@ class Codestream:
 
         return configs
 
-    def find_obj_path(self, arch, mod):
-        # We already know the path to vmlinux, so return it
-        if not is_mod(mod):
-            return self.get_boot_file("vmlinux", arch).relative_to(get_datadir(arch))
-
-        # Return the path if the modules was previously found for ARCH, or refetch if
-        # the obejct is for a different architecture
-        obj = self.modules.get(mod, "")
-        if obj:
-            assert self.kernel in str(obj)
-            return obj
-
+    def get_mod_file_path(self, arch, mod):
+        """
+        Getting the path to a module can be tricky, given how setup is invoked.
+        When --conf and --module are specified, the mod name is only a filename,
+        but when using the auto detection, the mod name is an entire path with
+        the module name.
+        """
         # Module name use underscores, but the final module object uses hyphens.
         mod = mod.replace("_", "[-_]")
-        mod_path = self.get_mod_path(arch)
+
+        # If the module is a path, we can return immediatly since we know where
+        # to find the module, but we need to prepend the kernel directory.
+        if "/" in mod:
+            return Path("kernel", mod)
 
         # If the setup subcommand was informing the module, here the module
         # name will only contain the name, otherwise it will contain the path
         # to the module.
-        if "/" in mod:
-            with open(Path(mod_path, "modules.order")) as f:
-                obj_match = re.search(rf"([\w\/\-]+\/{mod})\.ko", f.read())
-                if not obj_match:
-                    raise RuntimeError(f"{self.full_cs_name()}-{arch} ({self.kernel}): Module not found: {mod}")
+        mod_path = self.get_mod_path(arch)
+        with open(Path(mod_path, "modules.order")) as f:
+            obj_match = re.search(rf"([\w\/\-]+\/{mod})\.ko", f.read())
+            if not obj_match:
+                raise RuntimeError(f"{self.full_cs_name()}-{arch} ({self.kernel}): Module not found: {mod}")
 
-            fpath = Path(obj_match.group(1))
+        return Path(obj_match.group(1))
+
+    def __search_obj_in_dir(self, fdir, fname):
+        file_path = list(fdir.glob(f"{fname}.*"))
+
+        # The given file doesn't have an extension, so try again without it
+        if len(file_path) == 0:
+            file_path = list(fdir.glob(f"{fname}"))
+
+        # Make sure that we don't find duplicated files
+        assert len(file_path) == 1
+        return file_path[0]
+
+    def find_obj_path(self, arch, mod):
+        # Return the path if the modules was previously found for ARCH, or refetch if
+        # the obejct is for a different architecture
+        if is_mod(mod):
+            obj = self.modules.get(mod, "")
+            if obj:
+                assert self.kernel in str(obj)
+                return obj
+
+        # If the module cache failed or if mod is vmlinux, we need to find the
+        # path to the object
+        if not is_mod(mod):
+            fpath = Path(self.get_boot_dir(arch), self.get_boot_filename("vmlinux"))
         else:
-            fpath = mod
+            fpath = Path(self.get_mod_path(arch), self.get_mod_file_path(arch, mod))
 
-        fmod = f"{Path(mod_path, fpath)}.ko"
+        fmod = self.__search_obj_in_dir(fpath.parent, fpath.name)
 
         assert fmod.exists(), f"Module {str(fmod)} doesn't exists. Aborting"
 

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -68,6 +68,7 @@ def cleanup_obsolete_data(valid_codestreams):
 
     cleanup_obsolete_trees(valid_codestreams)
 
+
 def download_missing_cs_data(codestreams):
     cs_to_download = __get_cs_missing_data(codestreams)
     if cs_to_download:
@@ -82,8 +83,4 @@ def download_cs_data(codestreams):
 
 
 def __get_cs_missing_data(codestreams):
-    return [cs for cs in codestreams if __is_cs_data_missing(cs)]
-
-
-def __is_cs_data_missing(cs):
-    return not cs.get_boot_file("config").exists()
+    return [cs for cs in codestreams if not cs.get_mod_path().exists()]

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -276,7 +276,8 @@ def download_cs_rpms(cs_list):
                     subprocess.check_output(rf'gzip -k -d -f {f_path}', shell=True)
 
         # Use the SLE .config
-        shutil.copy(cs.get_boot_file("config"), Path(cs.get_obj_dir(), ".config"))
+        shutil.copy(Path(cs.get_boot_dir(), cs.get_boot_filename("config")),
+                    Path(cs.get_obj_dir(), ".config"))
 
         # Recreate the build link to enable us to test the generated LP
         mod_path = cs.get_kernel_build_path(ARCH)

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -258,23 +258,6 @@ def download_cs_rpms(cs_list):
     # Create a list of paths pointing to lib/modules for each downloaded
     # codestream
     for cs in cs_list:
-        for arch in cs.archs:
-            # Extract modules and vmlinux files that are compressed
-            mod_path = cs.get_mod_path(arch)
-            logging.info("extracting %s:%s in %s", arch, cs.full_cs_name(), str(mod_path))
-            for fext, ecmd in [("zst", "unzstd --rm -f -d"), ("xz", "xz --quiet -d -k")]:
-                cmd = rf'find {mod_path} -name "*.{fext}" -exec {ecmd} --quiet {{}} \;'
-                subprocess.check_output(cmd, shell=True)
-
-            # Extract gzipped files per arch
-            files = ["vmlinux", "symvers"]
-            for f in files:
-                f_path = cs.get_boot_file(f"{f}.gz", arch)
-                # ppc64le doesn't gzips vmlinux
-                if f_path.exists():
-                    logging.info("extracting %s:%s:%s", arch, cs.full_cs_name(), f)
-                    subprocess.check_output(rf'gzip -k -d -f {f_path}', shell=True)
-
         # Use the SLE .config
         shutil.copy(Path(cs.get_boot_dir(), cs.get_boot_filename("config")),
                     Path(cs.get_obj_dir(), ".config"))

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -140,7 +140,7 @@ def get_cs_packages(cs_list, dest):
 
 
 def find_missing_symbols(cs, arch, lp_mod_path):
-    vmlinux_path = cs.get_boot_file("vmlinux", arch)
+    vmlinux_path = cs.find_obj_path("vmlinux", arch)
     vmlinux_syms = get_all_symbols_from_object(vmlinux_path, True)
 
     # Get list of UNDEFINED symbols from the livepatch module

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -3,19 +3,23 @@
 # Copyright (C) 2021-2024 SUSE
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
+import gzip
 import io
 import logging
+import lzma
 import os
-from datetime import date, timedelta
-from pathlib import Path
 import platform
 import re
-import git
+from datetime import date, timedelta
+from pathlib import Path
 
+import git
+import magic
+
+import zstandard
 from elftools.common.utils import bytes2str
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
-
 from natsort import natsorted
 
 from klpbuild.klplib.config import get_user_path
@@ -174,7 +178,22 @@ def get_elf_object(obj):
     with open(obj, "rb") as f:
         data = f.read()
 
-    return ELFFile(io.BytesIO(data))
+    mime = magic.detect_from_filename(obj)
+
+    if "gzip" in mime.mime_type:
+        io_bytes = io.BytesIO(gzip.decompress(data))
+    elif "zstd" in mime.mime_type:
+        dctx = zstandard.ZstdDecompressor()
+        io_bytes = io.BytesIO(dctx.decompress(data))
+    elif "x-xz" in mime.mime_type:
+        io_bytes = io.BytesIO(lzma.decompress(data))
+    # Modules are x-object, while vmlinux is x-executable
+    elif "x-object" in mime.mime_type or "x-executable" in mime.mime_type:
+        io_bytes = io.BytesIO(data)
+    else:
+        raise RuntimeError(f"File {obj} with unknown format")
+
+    return ELFFile(io_bytes)
 
 
 # Load the ELF object and return all symbols

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -634,7 +634,7 @@ def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
     obj = cs.get_file_mod(fname)
 
     env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt() else "0"
-    env["KCP_MOD_SYMVERS"] = str(cs.get_boot_file("symvers"))
+    env["KCP_MOD_SYMVERS"] = str(Path(cs.get_boot_dir(), f'{cs.get_boot_filename("symvers")}.gz'))
     env["KCP_KBUILD_ODIR"] = str(cs.get_obj_dir())
     env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.preferred_arch([cs]))/cs.get_mod(obj))
     env["KCP_KBUILD_SDIR"] = str(cs.get_src_dir())

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         "pyelftools",
         "zstandard",
         "python-bugzilla",
+        "python-magic",
         "tabulate",
         "termcolor"
     ],

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -225,3 +225,24 @@ def test_boot_dir_and_filenames():
     assert "config-6.4.0" in cs.get_boot_filename("config")
     assert "symvers-6.4.0" in cs.get_boot_filename("symvers")
     assert "vmlinux-6.4.0" in cs.get_boot_filename("vmlinux")
+
+
+def test_get_mod_file_path():
+    cs = Codestream("15.7u5", kernel="6.4.0-150700.53.19")
+    assert "kernel/net/bluetooth/bluetooth" == str(cs.get_mod_file_path("x86_64", "bluetooth"))
+    assert "kernel/net/bluetooth/bluetooth" == str(cs.get_mod_file_path("x86_64", "net/bluetooth/bluetooth"))
+
+
+def test_find_obj_path():
+    cs = Codestream("15.7u5", kernel="6.4.0-150700.53.19")
+    assert "lib/modules/6.4.0-150700.53.19-default/kernel/net/bluetooth/bluetooth.ko.zst" == str(
+        cs.find_obj_path("x86_64", "bluetooth")
+    )
+    assert "lib/modules/6.4.0-150700.53.19-default/kernel/net/bluetooth/bluetooth.ko.zst" == str(
+        cs.find_obj_path("x86_64", "net/bluetooth/bluetooth")
+    )
+
+    cs = Codestream("16.0u0", kernel="6.12.0-160000.5")
+    assert "usr/lib/modules/6.12.0-160000.5-default/kernel/net/bluetooth/bluetooth.ko.zst" == str(
+        cs.find_obj_path("x86_64", "net/bluetooth/bluetooth")
+    )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -195,3 +195,33 @@ def test_symbol_with_noinstr_ibt():
         **lp_default_data
     }
     setup(**setup_args)
+
+
+def test_boot_dir():
+    cs = Codestream("16.0rtu0", kernel="6.12.0-160000.11")
+    # For SLFO codestreams, we get the boot files from the usr/lib/modules
+    assert "modules" in str(cs.get_boot_dir())
+
+    cs = Codestream("15.7u5", kernel="6.4.0-150700.53.19.1")
+    # In the old method, we need to point to /boot inside the codestream data
+    assert "boot" in str(cs.get_boot_dir())
+
+
+def test_boot_dir_and_filenames():
+    cs = Codestream("16.0rtu0", kernel="6.12.0-160000.11")
+    # For SLFO codestreams, we get the boot files from the usr/lib/modules
+    assert "modules" in str(cs.get_boot_dir())
+    # For SLFO codestreams, the filenames of the boot files do not contain the
+    # kernel version suffix
+    assert "config" == cs.get_boot_filename("config")
+    assert "symvers" == cs.get_boot_filename("symvers")
+    assert "vmlinux" == cs.get_boot_filename("vmlinux")
+
+    cs = Codestream("15.7u5", kernel="6.4.0-150700.53.19.1")
+    # In the old method, we need to point to /boot inside the codestream data
+    assert "boot" in str(cs.get_boot_dir())
+    # We older codestreams the boot files contains the kernel version as
+    # suffix
+    assert "config-6.4.0" in cs.get_boot_filename("config")
+    assert "symvers-6.4.0" in cs.get_boot_filename("symvers")
+    assert "vmlinux-6.4.0" in cs.get_boot_filename("vmlinux")


### PR DESCRIPTION
This PR solves #202 in a different way: instead of always extracting a module when necessary, we never extract them. Instead, we do it in runtime, so we don`t waste disk space with it.

When setup is running and downloading additional rpms files, it's not uncommon to developers to stop the process in the middle of it, skipping the extracting of kernel modules and vmlinux. The result is a half baked data directory, which requires further klp-build commands in order to have them extracted. This PR resolves this issue, decreasing the possiblity of such issues to happen.

This PR should be merged after only after https://github.com/SUSE/klp-ccp/pull/28 is merged. klp-ccp needs to be able to also decompress the files in runtime.