### PR TITLE
klplib/ibs: verify rpm download

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -61,6 +61,9 @@ Clean up the obsolete data generated for unsupported code streams.
 .B --update
 Download the missing codestreams data and clean up the obsolete data. It has the same result as
 --download and --cleanup-obsolete.
+.TP
+.B --verify-all
+Verify the integrity of all the downloaded RPM packages.
 .RE
 .TP
 .B scan

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -5,6 +5,7 @@
 
 import logging
 import shutil
+from pathlib import Path
 
 from klpbuild.klplib.utils import classify_codestreams_str,ARCHS
 from klpbuild.klplib.ibs import download_cs_rpms, verify_rpm
@@ -107,5 +108,18 @@ def verify_all_rpms():
         logging.info("All RPMs passed verification")
 
 
+def __cs_is_missing_data(cs):
+    '''
+    Verify that the vmlinux for each supported arch exists.
+    '''
+    for arch in cs.archs:
+        try:
+            cs.find_obj_path(arch, "vmlinux")
+        except AssertionError:
+            # Assert triggered: vmlinux was not found
+            return True
+    return False
+
+
 def __get_cs_missing_data(codestreams):
-    return [cs for cs in codestreams if not cs.get_mod_path().exists()]
+    return [cs for cs in codestreams if __cs_is_missing_data(cs)]

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -7,7 +7,7 @@ import logging
 import shutil
 
 from klpbuild.klplib.utils import classify_codestreams_str,ARCHS
-from klpbuild.klplib.ibs import download_cs_rpms
+from klpbuild.klplib.ibs import download_cs_rpms, verify_rpm
 from klpbuild.klplib.config import get_user_path
 from klpbuild.klplib.kernel_tree import  cleanup_obsolete_trees
 
@@ -80,6 +80,31 @@ def download_cs_data(codestreams):
                  classify_codestreams_str(codestreams))
     download_cs_rpms(codestreams)
     logging.info("Done.")
+
+
+def verify_all_rpms():
+    rpm_dir = get_user_path("data_dir") / "kernel-rpms"
+    if not rpm_dir.exists():
+        logging.error("RPM directory %s does not exist", rpm_dir)
+        return
+
+    rpms = sorted(rpm_dir.glob("*.rpm"))
+    if not rpms:
+        logging.info("No RPM files found in %s", rpm_dir)
+        return
+
+    logging.info("Verifying %d RPM files...", len(rpms))
+    failed = []
+    for r in rpms:
+        if not verify_rpm(r):
+            failed.append(r)
+            r.unlink()
+            logging.info("Deleted corrupted RPM: %s", r.name)
+
+    if failed:
+        logging.error("%d RPM(s) failed verification and were deleted", len(failed))
+    else:
+        logging.info("All RPMs passed verification")
 
 
 def __get_cs_missing_data(codestreams):

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -173,21 +173,42 @@ def validate_livepatch_module(cs, arch, rpm_dir, rpm):
     shutil.rmtree(Path(rpm_dir, "lib"), ignore_errors=True)
 
 
+def verify_rpm(rpm_path):
+    ret = subprocess.run(["rpm", "-K", str(rpm_path)],
+                            capture_output=True, text=True)
+    if ret.returncode != 0:
+        logging.error("RPM verification failed for %s", rpm_path)
+        return False
+    logging.debug("RPM verification passed for %s", rpm_path)
+    return True
+
+
 def download_binary_rpms(data: RPMData, total: int):
+
+    rpm_path = data.dest / data.rpm
+
+    if rpm_path.exists():
+        if not verify_rpm(rpm_path):
+            rpm_path.unlink(missing_ok=True)
+        else:
+            logging.info("(%d/%d) %s %s: already downloaded. skipping",
+                         data.index, total, data.cs.full_cs_name(), data.rpm)
+            return
+
     max_tries = 3
     for tries in range(1, max_tries + 1):
         try:
             data.osc.build.download_binary(data.prj, data.repo,
                                            data.arch, data.pkg, data.rpm,
                                            data.dest)
+            if not verify_rpm(rpm_path):
+                rpm_path.unlink(missing_ok=True)
+                raise RuntimeError(f"RPM verification failed: {data.rpm}")
+
             logging.info("(%d/%d) %s %s: ok", data.index, total,
                          data.cs.full_cs_name(), data.rpm)
             return
         except OSError as e:
-            if e.errno == errno.EEXIST:
-                logging.info("(%d/%d) %s %s: already downloaded. skipping",
-                             data.index, total, data.cs.full_cs_name(), data.rpm)
-                return
             if tries < max_tries:
                 logging.info("(%d/%d) %s %s: download failed (attempt %d/%d), retrying in 2s...",
                                 data.index, total, data.cs.full_cs_name(), data.rpm, tries, max_tries)

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from operator import itemgetter
 from pathlib import Path
 
@@ -173,18 +174,26 @@ def validate_livepatch_module(cs, arch, rpm_dir, rpm):
 
 
 def download_binary_rpms(data: RPMData, total: int):
-    try:
-        data.osc.build.download_binary(data.prj, data.repo,
-                                       data.arch, data.pkg, data.rpm,
-                                       data.dest)
-        logging.info("(%d/%d) %s %s: ok", data.index, total,
-                     data.cs.full_cs_name(), data.rpm)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            logging.info("(%d/%d) %s %s: already downloaded. skipping",
-                         data.index, total, data.cs.full_cs_name(), data.rpm)
-        else:
-            raise RuntimeError(f"download error on {data.cs.get_project_name()}: {data.rpm}") from e
+    max_tries = 3
+    for tries in range(1, max_tries + 1):
+        try:
+            data.osc.build.download_binary(data.prj, data.repo,
+                                           data.arch, data.pkg, data.rpm,
+                                           data.dest)
+            logging.info("(%d/%d) %s %s: ok", data.index, total,
+                         data.cs.full_cs_name(), data.rpm)
+            return
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                logging.info("(%d/%d) %s %s: already downloaded. skipping",
+                             data.index, total, data.cs.full_cs_name(), data.rpm)
+                return
+            if tries < max_tries:
+                logging.info("(%d/%d) %s %s: download failed (attempt %d/%d), retrying in 2s...",
+                                data.index, total, data.cs.full_cs_name(), data.rpm, tries, max_tries)
+                time.sleep(2)
+            else:
+                raise RuntimeError(f"download error on {data.cs.get_project_name()}: {data.rpm}") from e
 
 
 def download_and_extract(data, total):

--- a/klpbuild/plugins/data.py
+++ b/klpbuild/plugins/data.py
@@ -6,7 +6,7 @@
 import logging
 
 from klpbuild.klplib.cmd import add_arg_lp_filter
-from klpbuild.klplib.data import download_missing_cs_data, download_cs_data, cleanup_obsolete_data
+from klpbuild.klplib.data import download_missing_cs_data, download_cs_data, cleanup_obsolete_data, verify_all_rpms
 from klpbuild.klplib.supported import get_supported_codestreams
 from klpbuild.klplib.utils import filter_codestreams
 
@@ -26,8 +26,10 @@ def register_argparser(subparser):
                      help="Cleanup the obsolete files and directories")
     fmt.add_argument("--update", required=False, action="store_true",
                      help="Do the job of --download and --cleanup-obsolete")
+    fmt.add_argument("--verify-all", required=False, action="store_true",
+                     help="Verify the integrity of all downloaded RPM packages")
 
-def run(download, force, cleanup_obsolete, update, lp_filter):
+def run(download, force, cleanup_obsolete, update, verify_all, lp_filter):
     supported_codestreams =  get_supported_codestreams()
     filtered_codestreams = filter_codestreams(lp_filter, supported_codestreams)
 
@@ -38,5 +40,7 @@ def run(download, force, cleanup_obsolete, update, lp_filter):
             download_missing_cs_data(filtered_codestreams)
     if cleanup_obsolete or update:
         cleanup_obsolete_data(supported_codestreams)
-    if not (download or cleanup_obsolete or update):
-        logging.error("Use --download, --cleanup-obsolete or --update for this command")
+    if verify_all:
+        verify_all_rpms()
+    if not (download or cleanup_obsolete or update or verify_all):
+        logging.error("Use --download, --cleanup-obsolete, --update or --verify-all for this command")


### PR DESCRIPTION
- When network is unstable or IBS unreliable, retrying the download might work.
- new `--verify-all` command: Verify that rpm packages have a valid md5sum (`rpm -K` ) and valid signature. 
- Delete corrupted cs and download them again next time `klp-build data --download` is executed.