### PR TITLE
klplib: ibs: fix find_missing_symbols

### DIFF
--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -140,7 +140,7 @@ def get_cs_packages(cs_list, dest):
 
 
 def find_missing_symbols(cs, arch, lp_mod_path):
-    vmlinux_path = cs.find_obj_path("vmlinux", arch)
+    vmlinux_path = get_datadir(arch) / cs.find_obj_path(arch, "vmlinux")
     vmlinux_syms = get_all_symbols_from_object(vmlinux_path, True)
 
     # Get list of UNDEFINED symbols from the livepatch module


### PR DESCRIPTION
find_obj_path was called with incorrect argument order and vmlinux_path was lacking the base directory.