### PR TITLE
klplib/ibs: Do not verify downloaded rpm signature

### DIFF
--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -174,7 +174,7 @@ def validate_livepatch_module(cs, arch, rpm_dir, rpm):
 
 
 def verify_rpm(rpm_path):
-    ret = subprocess.run(["rpm", "-K", str(rpm_path)],
+    ret = subprocess.run(["rpm", "-K", "--nosignature", str(rpm_path)],
                             capture_output=True, text=True)
     if ret.returncode != 0:
         logging.error("RPM verification failed for %s", rpm_path)


### PR DESCRIPTION
In order for the rpm verification to work the system is required to have SUSE certificates installed and up to date, which might not be the case in older servers.  In such cases the verification process will fail.
This commit removes the signature checking. The most important feature of the verification is not anti-tampering, but data corruption detection, which is still being done.