### PR TITLE
file2config: Improve config analysis

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -93,4 +93,4 @@ jobs:
         mkdir -p ~/.config/klp-build &&
         cp tests/config ~/.config/klp-build/ &&
         mkdir -p klp/{livepatches,data} &&
-        tox -e tests -- tests/test_{ksrc,analysis,scan,config,kernel_tree,utils,codestream}.py
+        tox -e tests -- tests/test_{ksrc,analysis,file2config,scan,config,kernel_tree,utils,codestream}.py

--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -58,46 +58,84 @@ def _load_makefile(cs, make_file: str) -> list:
 
 
 def _sanitize_config(target):
-    config = target.strip('+=').strip().strip('obj-$(){}:').strip()
-    return config
+    m = re.search(r'CONFIG_\w+', target)
+    return m.group(0) if m else None
+
+
+def has_targets(make_lines):
+    """
+    Check if there are any objects (*.o) or dir reference in a makefile.
+      - obj-$(CONFIG_TLS) += tls.o — contains .o
+      - mlx5_core-y := main.o cmd.o debugfs.o — contains .o
+      - obj-y += steering/ — ends with / (subdirectory reference)
+    Not valid:
+      - subdir-ccflags-y += -I$(src)/..
+      - # SPDX-License-Identifier: GPL-2.0-only
+    """
+    return make_lines and\
+           any('.o' in l or l.endswith('/') for l in make_lines)
 
 
 def _find_config(cs, base_dir, relative_obj_path, deep):
+    """
+    Walk up the directory tree looking for the CONFIG option that enables
+    a given .o file. At each level, load the Kbuild or Makefile and search
+    for the object. If the target has a CONFIG (e.g. obj-$(CONFIG_TLS)),
+    return it. If it's unconditionally built (e.g. obj-y, setup-y), move
+    to the parent directory. Reaches the tree root as a last resort.
+    """
+
     if deep > 10:
         return None, ""
 
     if Path(".") == base_dir:
         return "CONFIG_SUSE_KERNEL", "vmlinux"
 
-    make_file = Path(base_dir, "Makefile")
-
-    lines = _load_makefile(cs, make_file)
-
+    lines = _load_makefile(cs, Path(base_dir, "Kbuild"))
     if not lines:
+        lines = _load_makefile(cs, Path(base_dir, "Makefile"))
+
+    # Skip Makefiles with no build targets (e.g. only compiler flags)
+    if not has_targets(lines):
         relative_obj_path = base_dir.name + "/" + relative_obj_path
         return _find_config(cs, base_dir.parent, relative_obj_path, deep+1)
 
     for line in lines:
         sep = line.split()
-        if relative_obj_path not in sep:
+        # Strip variable prefixes like $(obj)/ from tokens
+        tokens = [re.sub(r'\$[\({][^)}]*[\)}]/', '', t) for t in sep]
+        if relative_obj_path not in tokens:
             continue
 
-        # target found, check if this one with config
+        # target found, check if it has a CONFIG option
         target = sep[0]
-        if target.startswith('obj-y'):
-            # If it's built-in then check the config of the parent directory
-            return _find_config(cs, base_dir.parent, base_dir.name + '/', deep)
-        if target.startswith('obj-'):
-            return _sanitize_config(target), str((base_dir/relative_obj_path).with_suffix(''))
 
-        # target contains another object file rule, so strip it would and try
-        # again
+        config = _sanitize_config(target)
+        if config:
+            return config, str((base_dir/relative_obj_path).with_suffix(''))
+
+        # Unconditionally built (e.g. obj-y, setup-y): check if the target
+        # groups multiple .o files, otherwise check the parent directory
+        target = re.sub(r'[:+]?=$', '', target)
+        if re.match(r'\w+-y$', target):
+            filename = target.rsplit('-', 1)[0]
+            config, obj = _find_config(cs, base_dir, filename + '.o', deep + 1)
+            if config:
+                return config, obj
+            return _find_config(cs, base_dir.parent, base_dir.name + '/', deep)
+
+        # target contains another object file rule, strip the suffix and retry
         try:
             target, _ = target.rsplit('-', 1)
         except ValueError:
             continue
 
         return _find_config(cs, base_dir, target + '.o', deep + 1)
+
+    # Directory reference not found here, keep searching upward
+    if relative_obj_path.endswith('/'):
+        relative_obj_path = base_dir.name + "/" + relative_obj_path
+        return _find_config(cs, base_dir.parent, relative_obj_path, deep + 1)
 
     return None, ""
 

--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -140,7 +140,54 @@ def _find_config(cs, base_dir, relative_obj_path, deep):
     return None, ""
 
 
+def _find_including_obj(cs, base_dir, c_filename, lines):
+    """
+    Search .c files listed in the Makefile for one that #includes the
+    given c_filename. Return the matching .o, or None.
+    """
+
+    obj_files = set()
+    for line in lines:
+        for token in line.split():
+            if token.endswith('.o'):
+                obj_files.add(token)
+
+    for obj in obj_files:
+        c_file = str(Path(base_dir, obj.replace('.o', '.c')))
+        if not cs.check_file_exists(c_file):
+            continue
+        content = cs.read_file(c_file)
+        if content and f'#include "{c_filename}"' in content:
+            return obj
+
+    return None
+
+
+def _find_config_include(cs, base_dir, relative_obj_path):
+    """
+    Fallback for .c files not listed in the Makefile. Some kernel source
+    files are #included by other .c files instead of being compiled
+    directly. Search sibling .c files for an #include of the target,
+    and resolve the config for the including file instead.
+    """
+
+    if not relative_obj_path.endswith('.o'):
+        return None, ""
+
+    lines = _load_makefile(cs, Path(base_dir, "Makefile"))
+    if not lines:
+        return None, ""
+
+    c_filename = relative_obj_path.replace('.o', '.c')
+    including_obj = _find_including_obj(cs, base_dir, c_filename, lines)
+    if not including_obj:
+        return None, ""
+
+    return _find_config(cs, base_dir, including_obj, 0)
+
+
 def find_file_config(cs, path):
+
     path = path.strip()
 
     # Do not check headers
@@ -149,22 +196,22 @@ def find_file_config(cs, path):
 
     valid_path = _filter_path(path)
     obj_file = Path(valid_path.replace('.c', '.o'))
+
     config, obj = _find_config(cs, obj_file.parent, obj_file.name, 0)
     if not config:
-        return '', ''
+        config, obj = _find_config_include(cs, obj_file.parent, obj_file.name)
 
     # Detect code that is only enabled on a specific architecture.
     # Use a per-architecture generic CONFIG only if the found CONFIG
     # does not affect the same architecture as the one indicated in
     # the given file path.
     elif path.startswith("arch"):
-        archs = cs.get_all_configs(config)
         arch = _get_arch_in_path(path)
+        archs = cs.get_all_configs(config)
         if arch and (len(archs) != 1 or not archs.get(arch)):
             return archs_config[arch]['conf'], archs_config[arch]['module']
 
-    elif not config.startswith('CONFIG_'):
-        # Garbage like 'subst', 'vds' for wrongly parsed input
+    if not config or not config.startswith('CONFIG_'):
         return '', ''
 
     return config, obj

--- a/tests/test_file2config.py
+++ b/tests/test_file2config.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 SUSE
+# Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
+
+from pathlib import Path
+
+from klpbuild.klplib.codestream import Codestream
+from klpbuild.klplib.file2config import (
+    _filter_path,
+    _get_arch_in_path,
+    _sanitize_config,
+    _load_makefile,
+    _find_config,
+    find_file_config,
+    find_files_config,
+)
+
+
+CS = Codestream("15.5u15", kernel="5.14.21-150500.55.68")
+
+
+# -- _filter_path -------------------------------------------------------------
+
+
+def test_filter_path_no_match():
+    assert _filter_path("net/tls/tls_main.c") == "net/tls/tls_main.c"
+
+
+def test_filter_path_blacklist_match():
+    assert _filter_path("drivers/gpu/drm/amd/display/dc/core/dc.c") == "drivers/gpu/drm/amd/amdgpu/amdgpu_irq.c"
+
+
+def test_filter_path_blacklist_amdgpu_not_matched():
+    assert _filter_path("drivers/gpu/drm/amd/amdgpu/amdgpu_device.c") == "drivers/gpu/drm/amd/amdgpu/amdgpu_device.c"
+
+
+# -- _get_arch_in_path --------------------------------------------------------
+
+
+def test_get_arch_in_path_s390():
+    assert _get_arch_in_path("arch/s390/crypto/aes_s390.c") == "s390x"
+
+
+def test_get_arch_in_path_x86():
+    assert _get_arch_in_path("arch/x86/kernel/cpu/common.c") == "x86_64"
+
+
+def test_get_arch_in_path_powerpc():
+    assert _get_arch_in_path("arch/powerpc/kernel/entry_64.c") == "ppc64le"
+
+
+def test_get_arch_in_path_none():
+    assert _get_arch_in_path("net/tls/tls_main.c") is None
+
+
+# -- _sanitize_config ---------------------------------------------------------
+
+
+def test_sanitize_config_standard():
+    assert _sanitize_config("obj-$(CONFIG_TLS)") == "CONFIG_TLS"
+
+
+def test_sanitize_config_with_plus_equals():
+    assert _sanitize_config("obj-$(CONFIG_TLS) +=") == "CONFIG_TLS"
+
+
+def test_sanitize_config_curly_braces():
+    assert _sanitize_config("obj-${CONFIG_TLS}") == "CONFIG_TLS"
+
+
+def test_sanitize_config_setup_prefix():
+    assert _sanitize_config("setup-$(CONFIG_X86_APM_BOOT)") == "CONFIG_X86_APM_BOOT"
+
+
+def test_sanitize_config_no_config():
+    assert _sanitize_config("obj-y") is None
+
+
+# -- _load_makefile ------------------------------------------------------------
+
+
+def test_load_makefile_not_exists():
+    assert _load_makefile(CS, Path("nonexistent/dir/Makefile")) == []
+
+
+def test_load_makefile_simple():
+    lines = _load_makefile(CS, Path("net/tls/Makefile"))
+    assert any("obj-$(CONFIG_TLS)" in line for line in lines)
+
+
+def test_load_makefile_multiline_continuation():
+    lines = _load_makefile(CS, Path("kernel/Makefile"))
+    obj_y_line = [line for line in lines if line.startswith("obj-y")][0]
+    assert "fork.o" in obj_y_line
+    assert "async.o" in obj_y_line
+    assert "\\" not in obj_y_line
+
+
+# -- _find_config --------------------------------------------------------------
+
+
+def test_find_config_simple_obj_config():
+    config, obj = _find_config(CS, Path("net/tls"), "tls.o", 0)
+    assert config == "CONFIG_TLS"
+    assert obj == "net/tls/tls"
+
+
+def test_find_config_composite_object():
+    config, obj = _find_config(CS, Path("net/tls"), "tls_main.o", 0)
+    assert config == "CONFIG_TLS"
+    assert obj == "net/tls/tls"
+
+
+def test_find_config_obj_y_recurse_to_parent():
+    config, obj = _find_config(CS, Path("kernel"), "fork.o", 0)
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+def test_find_config_root_fallback():
+    config, obj = _find_config(CS, Path("."), "anything.o", 0)
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+def test_find_config_not_found_in_makefile():
+    config, obj = _find_config(CS, Path("net/tls"), "nonexistent.o", 0)
+    assert config is None
+    assert obj == ""
+
+
+def test_find_config_block_simple():
+    config, obj = _find_config(CS, Path("block"), "bsg.o", 0)
+    assert config == "CONFIG_BLK_DEV_BSG_COMMON"
+    assert obj == "block/bsg"
+
+
+def test_find_config_setup_y_target():
+    config, obj = _find_config(CS, Path("arch/x86/boot"), "cpuflags.o", 0)
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+def test_find_config_kbuild_scattered():
+    config, obj = _find_config(CS, Path("arch/x86/kernel/cpu"), "scattered.o", 0)
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+def test_find_config_dir_ref_not_in_makefile():
+    config, obj = _find_config(CS, Path("arch/x86"), "boot/", 0)
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+# -- find_file_config ----------------------------------------------------------
+
+
+def test_find_file_config_header_skipped():
+    assert find_file_config(CS, "include/linux/tls.h") == ("", "")
+
+
+def test_find_file_config_simple():
+    config, obj = find_file_config(CS, "net/tls/tls.c")
+    assert config == "CONFIG_TLS"
+    assert obj == "net/tls/tls"
+
+
+def test_find_file_config_composite_object():
+    config, obj = find_file_config(CS, "net/tls/tls_main.c")
+    assert config == "CONFIG_TLS"
+    assert obj == "net/tls/tls"
+
+
+def test_find_file_config_blacklisted_path():
+    config, _ = find_file_config(CS, "drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c")
+    assert config == "CONFIG_DRM_AMDGPU"
+
+
+def test_find_file_config_no_config_found():
+    assert find_file_config(CS, "net/tls/nonexistent.c") == ("", "")
+
+
+def test_find_file_config_arch_single_correct_arch():
+    config, obj = find_file_config(CS, "arch/s390/crypto/aes_s390.c")
+    assert config == "CONFIG_CRYPTO_AES_S390"
+    assert obj == "arch/s390/crypto/aes_s390"
+
+
+def test_find_file_config_builtin_to_root():
+    config, obj = find_file_config(CS, "kernel/fork.c")
+    assert config == "CONFIG_SUSE_KERNEL"
+    assert obj == "vmlinux"
+
+
+def test_find_file_config_strips_whitespace():
+    config, _ = find_file_config(CS, "  net/tls/tls.c  ")
+    assert config == "CONFIG_TLS"
+
+
+def test_find_file_config_cpuflags():
+    config, obj = find_file_config(CS, "arch/x86/boot/cpuflags.c")
+    assert config == "CONFIG_X86_64"
+    assert obj == "vmlinux"
+
+
+def test_find_file_config_scattered():
+    config, obj = find_file_config(CS, "arch/x86/kernel/cpu/scattered.c")
+    assert config == "CONFIG_X86_64"
+    assert obj == "vmlinux"
+
+
+def test_find_file_config_obj_prefix_variable():
+    config, _ = find_file_config(CS, "arch/x86/boot/compressed/sev.c")
+    assert config == "CONFIG_AMD_MEM_ENCRYPT"
+
+
+def test_find_file_config_nested_subdir():
+    config, _ = find_file_config(CS, "drivers/net/ethernet/mellanox/mlx5/core/steering/dr_domain.c")
+    assert config == "CONFIG_MLX5_SW_STEERING"
+
+
+# -- find_files_config ---------------------------------------------------------
+
+
+def test_find_files_config_empty_list():
+    configs, missing = find_files_config(CS, [])
+    assert not configs
+    assert not missing
+
+
+def test_find_files_config_single_found():
+    configs, missing = find_files_config(CS, ["net/tls/tls.c"])
+    assert "net/tls/tls.c" in configs
+    assert configs["net/tls/tls.c"]["conf"] == "CONFIG_TLS"
+    assert not missing
+
+
+def test_find_files_config_single_missing():
+    configs, missing = find_files_config(CS, ["include/linux/tls.h"])
+    assert not configs
+    assert missing == ["include/linux/tls.h"]
+
+
+def test_find_files_config_mixed():
+    configs, missing = find_files_config(CS, ["net/tls/tls.c", "include/linux/tls.h", "net/tls/nonexistent.c"])
+    assert "net/tls/tls.c" in configs
+    assert "include/linux/tls.h" in missing
+    assert "net/tls/nonexistent.c" in missing


### PR DESCRIPTION
This PR focuses on improving `file2config` feature to cover some edge cases found until now. It also adds a most necessary test coverage.

Before `scan` failed to find a config for `fs_hws.c`:
```
16.0rtu0-1 16.0u0-1:
 FILE: drivers/net/ethernet/mellanox/mlx5/core/steering/hws/fs_hws.c
```

Now:
```
16.0rtu0-1 16.0u0-1:
FILE: drivers/net/ethernet/mellanox/mlx5/core/steering/hws/fs_hws.c
CONF: CONFIG_MLX5_HW_STEERING
OBJ: drivers/net/ethernet/mellanox/mlx5/core/steering/hws/fs_hws
FUNCS: mlx5_fs_get_hws_action, mlx5_fs_create_hws_action, mlx5_fs_put_hws_action
```

This PR cannot be merged before #229 