### PR TITLE
chore: remove explicit configparser dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
         "console_scripts": ["klp-build=klpbuild.main:main"],
     },
     install_requires=[
-        "configparser",
         "cached_property",
         "GitPython",
         "lxml",


### PR DESCRIPTION
configparser is now a built-in utility into Python so there's no need to explicitly mention it as a dependency