### PR TITLE
Prepare cleanup

### DIFF
--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -23,7 +23,7 @@ from osctiny import Osc
 
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.config import get_user_settings
-from klpbuild.klplib.utils import ARCH, get_all_symbols_from_object, get_datadir
+from klpbuild.klplib.utils import ARCH, ARCHS, get_all_symbols_from_object, get_datadir
 
 logging.getLogger("osctiny").setLevel(logging.WARNING)
 
@@ -65,7 +65,7 @@ def do_work(func, args: list[RPMData]):
 # We can try delete a project that was removed, so don't bother with errors
 def delete_built_rpms(cs, lp_name):
     try:
-        for arch in cs.archs:
+        for arch in ARCHS:
             shutil.rmtree(Path(cs.get_ccp_dir(lp_name), arch, "rpm"), ignore_errors=True)
     except KeyError:
         pass

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -75,7 +75,7 @@ def download_built_rpms(lp_name, lp_filter):
     logging.info("Download finished.")
 
 
-def prepare_tests(lp_name, lp_filter):
+def run(lp_name, lp_filter):
     test_src = get_tests_path(lp_name)
     if test_src and not os.access(test_src, os.X_OK):
         logging.error("Script %s has no execution bit set. Aborting", test_src)
@@ -153,7 +153,3 @@ def prepare_tests(lp_name, lp_filter):
         )
 
         logging.info("Done.")
-
-
-def run(lp_name, lp_filter):
-    prepare_tests(lp_name, lp_filter)

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -114,15 +114,12 @@ def prepare_tests(lp_name, lp_filter):
                 logging.info("%s/%s: rpm dir not found. Skipping.", cs.full_cs_name(), arch)
                 continue
 
-            # TODO: there will be only one rpm, format it directly
+            rpms = list(rpm_dir.glob("**/*.rpm"))
+            assert len(rpms) == 1, f"{cs.full_cs_name()}/{arch}: {len(rpms)} rpms found. Expecting only one"
 
-            rpms = [rpm for rpm in os.listdir(rpm_dir) if rpm.endswith(".rpm")]
-            if len(rpms) > 1:
-                raise RuntimeError(f"ERROR: {cs.full_cs_name()}/{arch}. {len(rpms)} rpms found. Excepting to find only one")
-
-            for rpm in rpms:
-                validate_livepatch_module(cs, arch, rpm_dir, rpm)
-                shutil.copy(Path(rpm_dir, rpm), Path(test_arch_path, "built"))
+            rpm_file = rpms[0]
+            validate_livepatch_module(cs, arch, rpm_dir, rpm_file)
+            shutil.copy(Path(rpm_dir, rpm_file), Path(test_arch_path, "built"))
 
             if cs.rt and arch != "x86_64":
                 continue

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -121,9 +121,6 @@ def prepare_tests(lp_name, lp_filter):
             validate_livepatch_module(cs, arch, rpm_dir, rpm_file)
             shutil.copy(Path(rpm_dir, rpm_file), Path(test_arch_path, "built"))
 
-            if cs.rt and arch != "x86_64":
-                continue
-
             build_cs.append(cs.get_full_product_name())
 
         logging.info("Done.")

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -3,20 +3,35 @@
 # Copyright (C) 2025 SUSE
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
+import concurrent.futures
 import importlib
 import logging
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 from natsort import natsorted
 from osctiny import Osc
 
-from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
-from klpbuild.klplib.codestreams_data import get_codestream_by_name, get_codestreams_list
-from klpbuild.klplib.ibs import convert_prj_to_cs, delete_built_rpms, delete_project, do_work, download_binary_rpms, get_projects, prj_prefix, validate_livepatch_module, RPMData
+from klpbuild.klplib.cmd import add_arg_lp_filter, add_arg_lp_name
+from klpbuild.klplib.codestreams_data import (
+    get_codestream_by_name,
+    get_codestreams_list,
+)
+from klpbuild.klplib.config import get_user_settings
+from klpbuild.klplib.ibs import (
+    RPMData,
+    convert_prj_to_cs,
+    delete_built_rpms,
+    delete_project,
+    do_work,
+    download_binary_rpms,
+    get_projects,
+    prj_prefix,
+    validate_livepatch_module,
+)
 from klpbuild.klplib.utils import ARCHS, filter_codestreams, get_tests_path, get_workdir
 
 PLUGIN_CMD = "prepare-tests"
@@ -75,6 +90,32 @@ def download_built_rpms(lp_name, lp_filter):
     logging.info("Download finished.")
 
 
+def validate_module_and_move(cs, arch, lp_name, test_arch_path):
+    """
+    Validate a livepatch module and move it to the test directory.
+
+    Returns the codestream's full product name on success, None on failure.
+    """
+    rpm_dir = Path(cs.get_ccp_dir(lp_name), arch, "rpm")
+    if not rpm_dir.exists():
+        logging.warning("%s/%s: rpm dir not found. Skipping.", cs.full_cs_name(), arch)
+        return None
+
+    # Skip codestreams with more than one rpm, and none. There is an issue elsewhere.
+    rpm_files = list(rpm_dir.rglob("*.rpm"))
+    if len(rpm_files) != 1:
+        logging.warning("%s/%s: expected 1 rpm, found %d. Skipping.", cs.full_cs_name(), arch, len(rpm_files))
+        return None
+
+    # There should be only one rpm, so take the first entry in the list
+    rpm_path = rpm_files[0]
+    rpm_file = rpm_path.name
+    validate_livepatch_module(cs, arch, rpm_dir, rpm_file)
+    shutil.move(rpm_path, Path(test_arch_path, "built"))
+
+    return cs.get_full_product_name()
+
+
 def run(lp_name, lp_filter):
     test_src = get_tests_path(lp_name)
     if test_src and not os.access(test_src, os.X_OK):
@@ -104,24 +145,26 @@ def run(lp_name, lp_filter):
             Path(test_arch_path, d).mkdir(exist_ok=True)
 
         logging.info("Checking %s symbols...", arch)
-        build_cs = []
-        for cs in filter_codestreams(lp_filter, get_codestreams_list()):
-            if arch not in cs.get_default_archs():
-                continue
 
-            rpm_dir = Path(cs.get_ccp_dir(lp_name), arch, "rpm")
-            if not rpm_dir.exists():
-                logging.info("%s/%s: rpm dir not found. Skipping.", cs.full_cs_name(), arch)
-                continue
+        # Prepare list of codestreams to validate
+        cs_to_validate = [
+            cs for cs in filter_codestreams(lp_filter, get_codestreams_list())
+            if arch in cs.get_default_archs()
+        ]
 
-            rpms = list(rpm_dir.glob("**/*.rpm"))
-            assert len(rpms) == 1, f"{cs.full_cs_name()}/{arch}: {len(rpms)} rpms found. Expecting only one"
+        # Validate modules in parallel using processes (not threads) to avoid
+        # thread-safety issues with underlying C libraries
+        workers = int(get_user_settings("workers"))
+        with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
+            futures = [
+                executor.submit(validate_module_and_move, cs, arch, lp_name, test_arch_path)
+                for cs in cs_to_validate
+            ]
+            concurrent.futures.wait(futures)
 
-            rpm_file = rpms[0]
-            validate_livepatch_module(cs, arch, rpm_dir, rpm_file)
-            shutil.copy(Path(rpm_dir, rpm_file), Path(test_arch_path, "built"))
-
-            build_cs.append(cs.get_full_product_name())
+            # Collect successful results
+            results = [future.result() for future in futures]
+            validated_cs = [r for r in results if r is not None]
 
         logging.info("Done.")
 
@@ -141,7 +184,7 @@ def run(lp_name, lp_filter):
             config = Path(test_dst, "config.in")
 
         with open(config, "w") as f:
-            f.write("\n".join(natsorted(build_cs)))
+            f.write("\n".join(natsorted(validated_cs)))
 
         logging.info("Creating %s tar file...", arch)
         subprocess.run(

--- a/klpbuild/plugins/prepare_tests.py
+++ b/klpbuild/plugins/prepare_tests.py
@@ -25,7 +25,7 @@ PLUGIN_CMD = "prepare-tests"
 def register_argparser(subparser):
     test = subparser.add_parser(
         PLUGIN_CMD,
-        help="Download the built tests and check for LP dependencies",
+        help="Download the built livepatch packages",
     )
 
     add_arg_lp_name(test)
@@ -121,9 +121,7 @@ def prepare_tests(lp_name, lp_filter):
                 raise RuntimeError(f"ERROR: {cs.full_cs_name()}/{arch}. {len(rpms)} rpms found. Excepting to find only one")
 
             for rpm in rpms:
-                # Check for dependencies
                 validate_livepatch_module(cs, arch, rpm_dir, rpm)
-
                 shutil.copy(Path(rpm_dir, rpm), Path(test_arch_path, "built"))
 
             if cs.rt and arch != "x86_64":


### PR DESCRIPTION
These patches are mostly cosmetic but the last one. It reduced the time to run prepare tests for me from 25 minutes to 12 minutes, which itself is huge.  I'm using workers=4, but the gains could be much higher if the number of workers is bigger.