### PR TITLE
klplib: codestream: set default value for 'eol' and 'required_patches'

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -61,6 +61,9 @@ class Codestream:
 
     @classmethod
     def from_data(cls, data):
+        data.setdefault("eol", "")
+        data.setdefault("required_patches", None)
+
         return cls(data["name"], data["project"], data["patchid"],
                    data["kernel"], data["eol"], data["archs"], data["files"],
                    data["modules"], data["configs"], data["required_patches"])


### PR DESCRIPTION
it's possible to get a key error if the file codestreams.json doesn't have the 'eol' and 'required_patches' items, which was generated by an old version klp-build tool.
===============================
While in the process of working for a LP project, I updated the klp-build tool. The original codestreams.josn doesn't 
include 'eol' and 'required_patches' items, so I get the following error:
```
# klp-build cs-diff -n bsc1262759 --filter '16.0u1|16.0u9'
Traceback (most recent call last):
  File "/root/.local/bin/klp-build", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/work/source/klp-build/klpbuild/main.py", line 24, in main
    load_codestreams(args.lp_name)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/work/source/klp-build/klpbuild/klplib/codestreams_data.py", line 48, in load_codestreams
    _codestreams[cs] = Codestream.from_data(json_cs[cs])
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/work/source/klp-build/klpbuild/klplib/codestream.py", line 68, in from_data
    data["kernel"], data["eol"], data["archs"], data["files"],
                    ~~~~^^^^^^^
KeyError: 'eol'
```

The same error for key 'required_patches' .