### PR TITLE
klplib: codestream: check if module is duplicate

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -437,6 +437,9 @@ class Codestream:
         return Path(obj_match.group(1))
 
     def __search_obj_in_dir(self, fdir, fname):
+        # If no suffix in fname, we'll get a false assert
+        if not fname.endswith(".ko"):
+            fname += ".ko"
         file_path = list(fdir.glob(f"{fname}.*"))
 
         # The given file doesn't have an extension, so try again without it


### PR DESCRIPTION
The fname passed into __search_obj_in_dir() is just the basename of module without any suffix. So if the module is present both in compressed and decompressed format, we'll get a false assert in this function. Such as
```
localhost:/work/klp/data/x86_64/usr/lib/modules/6.4.0-37-rt # ll kernel/drivers/usb/usbip
total 412
-rw-r--r-- 1 root root  80072 Oct 23  2025 usbip-core.ko
-rw-r--r-- 1 root root  18311 Oct 23  2025 usbip-core.ko.zst
-rw-r--r-- 1 root root 103416 Oct 23  2025 usbip-host.ko
-rw-r--r-- 1 root root  26477 Oct 23  2025 usbip-host.ko.zst
-rw-r--r-- 1 root root 147160 Oct 23  2025 vhci-hcd.ko
-rw-r--r-- 1 root root  35413 Oct 23  2025 vhci-hcd.ko.zst
```
