### PR TITLE
Fix --conf-mod-file-funcs argument of setup subcommand

### DIFF
--- a/klpbuild/klplib/affected_file.py
+++ b/klpbuild/klplib/affected_file.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+from enum import Enum
+from pathlib import PurePosixPath
+
+from klpbuild.klplib.utils import ARCHS
+
+
+class AffectedModule:
+    """
+    A kernel object potentially patched by a livepatch.
+
+    Covers both loadable ``.ko`` modules (e.g. ``"fs/ext4/ext4"``) and
+    ``vmlinux`` itself.
+
+    The same module instance is shared by every source
+    file compiled into it.
+    """
+
+    VMLINUX = "vmlinux"
+
+    def __init__(self, name: str):
+        self.name = name                            # e.g. "fs/ext4/ext4" or "vmlinux"
+        self.supported: bool | None = None          # None = not yet checked
+        self.blacklisted: bool = False              # not supported for livepatching
+        self._obj_paths: dict[str, str] = {}        # arch -> resolved on-disk path
+
+    @classmethod
+    def vmlinux(cls) -> "AffectedModule":
+        """
+        Create the canonical :attr:`VMLINUX` :class:`AffectedModule`.
+        """
+        m = cls(cls.VMLINUX)
+        m.supported = True
+        return m
+
+    @property
+    def is_vmlinux(self) -> bool:
+        """``True`` if this module represents the kernel image (``vmlinux``)."""
+        return self.name == self.VMLINUX
+
+    @property
+    def lp_module_name(self) -> str:
+        """
+        Return the module name formatted for livepatch ``LP_MODULE``
+        kallsyms lookup strings.
+        """
+        return PurePosixPath(self.name.replace("-", "_")).name
+
+    def set_obj_path(self, arch: str, path: str) -> None:
+        """Cache the resolved on-disk object path for ``arch``."""
+        if arch not in ARCHS:
+            raise ValueError(f"Unknown arch: {arch}")
+        self._obj_paths[arch] = path
+
+    def get_obj_path(self, arch: str) -> str | None:
+        """Return the cached on-disk object path for ``arch``, or ``None``."""
+        if arch not in ARCHS:
+            raise ValueError(f"Unknown arch: {arch}")
+        return self._obj_paths.get(arch)
+
+    @classmethod
+    def from_dict(cls, name: str, data: dict) -> "AffectedModule":
+        """Reconstruct an :class:`AffectedModule` from the dict produced by :meth:`to_dict`."""
+        m = cls(name)
+        m.supported   = data["supported"]
+        m.blacklisted = data["blacklisted"]
+        for arch, path in data["obj_paths"].items():
+            m.set_obj_path(arch, path)
+        return m
+
+    def to_dict(self) -> dict:
+        """Return a plain dict suitable for JSON serialization."""
+        return {
+            "supported": self.supported,
+            "blacklisted": self.blacklisted,
+            "obj_paths": dict(self._obj_paths),
+        }
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AffectedModule):
+            return NotImplemented
+        return self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __str__(self) -> str:
+        # Renders as the bare module name (e.g. "vmlinux" or "fs/ext4/ext4")
+        # so f-strings can interpolate an :class:`AffectedModule` directly into
+        # output paths and template lines.
+        return self.name
+
+    def __repr__(self) -> str:
+        return (f"AffectedModule(name={self.name!r}, "
+                f"supported={self.supported!r}, "
+                f"blacklisted={self.blacklisted!r})")
+
+
+class ConfigState(Enum):
+    """
+    Possible values of a kernel configuration option on a given architecture.
+
+    The ``value`` of each member matches the character used by the kernel build
+    system.
+    """
+    NOT_SET = "n"
+    MODULE  = "m"
+    BUILTIN = "y"
+
+
+class AffectedConfig:
+    """
+    A kernel configuration option (e.g. ``CONFIG_FOO``) together with its
+    state on each supported architecture.
+
+    Architectures that were never set are reported as
+    :attr:`ConfigState.NOT_SET`.
+    """
+
+    def __init__(self, config_name: str,
+                 arch_values: dict[str, str] | None = None):
+        if not config_name.startswith("CONFIG_"):
+            raise ValueError(
+                f"Invalid config '{config_name}': missing CONFIG_ prefix")
+
+        self.config_name = config_name
+        self._values: dict[str, ConfigState] = {}
+
+        for arch, value in (arch_values or {}).items():
+            self.set_arch(arch, ConfigState(value))
+
+    def set_arch(self, arch: str, value: ConfigState) -> None:
+        """
+        Set the configuration state for ``arch``.
+
+        Setting an arch to :attr:`ConfigState.NOT_SET` removes it from the
+        internal mapping so that :meth:`archs` and :meth:`is_set` keep their
+        natural meaning.
+        """
+        if arch not in ARCHS:
+            raise ValueError(f"Unknown arch: {arch}")
+
+        if value is ConfigState.NOT_SET:
+            self._values.pop(arch, None)
+        else:
+            self._values[arch] = value
+
+    def get_arch(self, arch: str) -> ConfigState:
+        """
+        Return the :class:`ConfigState` for ``arch``, defaulting to
+        :attr:`ConfigState.NOT_SET` when the arch was never set.
+        """
+        if arch not in ARCHS:
+            raise ValueError(f"Unknown arch: {arch}")
+        return self._values.get(arch, ConfigState.NOT_SET)
+
+    def archs(self) -> set[str]:
+        """Return the set of architectures where this config is set (``y`` or ``m``)."""
+        return set(self._values)
+
+    # NOTE: not yet used
+    def is_builtin_on_any(self) -> bool:
+        """``True`` if the config is built into vmlinux on at least one arch."""
+        return ConfigState.BUILTIN in self._values.values()
+
+    def is_module_on_any(self) -> bool:
+        """``True`` if the config is built as a module on at least one arch."""
+        return ConfigState.MODULE in self._values.values()
+
+    def is_set(self) -> bool:
+        """``True`` if the config has any value (``y`` or ``m``) on any arch."""
+        return bool(self._values.keys())
+
+    @classmethod
+    def from_dict(cls, name: str, data: dict[str, str]) -> "AffectedConfig":
+        """Reconstruct an :class:`AffectedConfig` from the dict produced by :meth:`to_dict`."""
+        return cls(name, data)
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a plain ``{arch: 'y'|'m'}`` dict suitable for JSON serialization."""
+        return {arch: state.value for arch, state in self._values.items()}
+
+    def __bool__(self) -> bool:
+        return self.is_set()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AffectedConfig):
+            return NotImplemented
+        return (self.config_name == other.config_name
+                and self._values == other._values)
+
+    def __hash__(self) -> int:
+        return hash((self.config_name, frozenset(self._values.items())))
+
+    def __str__(self) -> str:
+        # Concise human-readable form for log output and report keys,
+        # e.g. "CONFIG_FOO(x86_64=m, s390x=y)" or "CONFIG_FOO(not set)".
+        if self._values:
+            archs = ", ".join(f"{a}={s.value}"
+                              for a, s in sorted(self._values.items()))
+            return f"{self.config_name}({archs})"
+        return f"{self.config_name}(not set)"
+
+    def __repr__(self) -> str:
+        return f"AffectedConfig({self.config_name!r}, {self.to_dict()!r})"
+
+
+class AffectedFile:
+    """
+    A Linux kernel source file modified we are livepatching.
+
+    Holds analysis-phase metadata (the file's identity together with name-key
+    cross-references into ``cs.configs`` and ``cs.modules`` and the set of
+    symbols to be patched) and extraction-phase artifacts populated by
+    ``klp-ccp`` during the extract step (see ``plugins/extract.py``).
+    """
+
+    def __init__(self, filename: str, *,
+                 config_name: str | None = None,
+                 module_name: str | None = None,
+                 affected_symbols: set[str] | None = None):
+        # Analysis-phase metadata
+        self.filename = filename
+        self.config_name = config_name              # key into cs.configs
+        self.module_name = module_name              # key into cs.modules
+        self.affected_symbols: set[str] = set(affected_symbols or ())
+
+        # Extraction-phase artifacts (populated by extract.py)
+        self.ibt: bool = False
+        self.dup_symbols: list[str] = []
+        self.ext_symbols: dict[str, list[str]] = {}     # module name → symbol list
+        self.klpp_symbols: dict[str, str] = {}          # symbol name → prototype
+
+    @classmethod
+    def from_dict(cls, filename: str, data: dict) -> "AffectedFile":
+        """Reconstruct an :class:`AffectedFile` from the dict produced by :meth:`to_dict`."""
+        f = cls(
+            filename,
+            config_name=data["config_name"],
+            module_name=data["module_name"],
+            affected_symbols=set(data["affected_symbols"]),
+        )
+        f.ibt          = data["ibt"]
+        f.dup_symbols  = list(data["dup_symbols"])
+        f.ext_symbols  = dict(data["ext_symbols"])
+        f.klpp_symbols = dict(data["klpp_symbols"])
+        return f
+
+    def to_dict(self) -> dict:
+        """Return a plain dict suitable for JSON serialization."""
+        return {
+            "config_name": self.config_name,
+            "module_name": self.module_name,
+            "affected_symbols": sorted(self.affected_symbols),
+            "ibt": self.ibt,
+            "dup_symbols": list(self.dup_symbols),
+            "ext_symbols": dict(self.ext_symbols),
+            "klpp_symbols": dict(self.klpp_symbols),
+        }
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AffectedFile):
+            return NotImplemented
+        return self.filename == other.filename
+
+    def __hash__(self) -> int:
+        return hash(self.filename)
+
+    def __repr__(self) -> str:
+        return (f"AffectedFile(filename={self.filename!r}, "
+                f"config_name={self.config_name!r}, "
+                f"module_name={self.module_name!r})")

--- a/klpbuild/klplib/analysis.py
+++ b/klpbuild/klplib/analysis.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.file2config import find_file_config
+from klpbuild.klplib.affected_file import AffectedFile, AffectedModule
 from klpbuild.klplib.ksrc import get_patches_files
 
 
@@ -53,8 +54,12 @@ def __analyse_cs_files(cs, files):
         conf, obj = find_file_config(cs, file)
         funcs = __extract_functions(diffs)
         if conf:
-            cs.files[file] = {'symbols': list(funcs),
-                              'conf': conf, 'module': obj}
+            cs.files[file] = AffectedFile(
+                    file,
+                    config_name=conf,
+                    module_name=obj,
+                    affected_symbols=set(funcs),
+                )
             key = f"{file}:{conf}:{obj}:{sorted(funcs)}"
         else:
             key = f"{file}:::"
@@ -116,11 +121,10 @@ def print_files(report):
             logging.info("%s:\nFILE: %s\n", cs_str, file)
             continue
 
-        conf = cs.files[file]['conf']
-        obj = cs.files[file]['module']
-        funcs = cs.files[file]['symbols']
+        fdata = cs.files[file]
         logging.info("%s:\nFILE: %s\nCONF: %s\nOBJ: %s\nFUNCS: %s\n",
-                     cs_str, file, conf, obj, ', '.join(funcs))
+                     cs_str, file, fdata.config_name, fdata.module_name,
+                     ', '.join(sorted(fdata.affected_symbols)))
 
 
 def analyse_configs(cs_list):
@@ -138,7 +142,7 @@ def analyse_configs(cs_list):
     report = defaultdict(list)
 
     for cs in cs_list:
-        configs = {dat['conf'] for _, dat in cs.files.items()}
+        configs = {f.config_name for f in cs.files.values()}
         cs.set_configs(configs)
         for conf, archs in cs.configs.items():
             key = f"{conf}:{archs}"
@@ -148,19 +152,15 @@ def analyse_configs(cs_list):
     return report
 
 
-def __get_arch_config(conf, arch):
-    return conf[arch] if arch in conf else 'n'
-
-
 def print_configs(report):
 
     for key, cs_list in report.items():
         cs = cs_list[0]
         c = key.split(':')[0]
-        conf = cs.configs[c]
-        x86_64 = __get_arch_config(conf, "x86_64")
-        ppc64le = __get_arch_config(conf, "ppc64le")
-        s390x = __get_arch_config(conf, "s390x")
+        cfg = cs.configs[c]
+        x86_64 = cfg.get_arch("x86_64").value
+        ppc64le = cfg.get_arch("ppc64le").value
+        s390x = cfg.get_arch("s390x").value
         cs_str = utils.classify_codestreams_str(cs_list)
         logging.info("%s:\nCONF: %s\nx86_64: %s\nppc64le: %s\ns390x: %s\n",
                      cs_str, c, x86_64, ppc64le, s390x)
@@ -175,7 +175,7 @@ def filter_unset_configs(cs_list):
         if not cs.configs:
             continue
 
-        isset = [conf for conf, archs in cs.configs.items() if archs]
+        isset = [conf for conf, cfg in cs.configs.items() if cfg.is_set()]
         if not isset:
             unset_cs.append(cs)
             unset_conf += list(cs.configs)
@@ -201,24 +201,32 @@ def analyse_kmodules(cs_list):
     report = defaultdict(list)
 
     for cs in cs_list:
-        for _, dat in cs.files.items():
-            conf = dat['conf']
-            mod = dat['module']
-            if mod in cs.modules:
+        # Per-codestream local dedup. Previously this scribbled bool flags into
+        # cs.modules and patch.filter_unsupported_kmodules called .clear()
+        # afterwards; with AffectedModule the supported / blacklisted fields
+        # live on the persistent module object, so dedup needs its own scratch
+        # set to avoid touching cs.modules until we have a real result.
+        seen: set[str] = set()
+        for f in cs.files.values():
+            mod_name = f.module_name
+            if mod_name in seen:
+                continue
+            seen.add(mod_name)
+
+            # Check if it's built as a module on at least one arch
+            if not cs.configs[f.config_name].is_module_on_any():
                 continue
 
-            # Check if it's not built-in for any arch
-            if 'm' not in [val for _, val in
-                           cs.configs[conf].items()]:
-                continue
-
-            supported, blacklisted = cs.is_module_supported(mod)
+            supported, blacklisted = cs.is_module_supported(mod_name)
             if blacklisted:
                 logging.warning("%s: Module '%s' is not supported by klp-build.",
-                                cs.full_cs_name(), PurePosixPath(mod).name)
+                                cs.full_cs_name(), PurePosixPath(mod_name).name)
 
-            cs.modules[mod] = supported
-            key = f"{mod}:{supported}"
+            mod_obj = cs.modules.setdefault(mod_name, AffectedModule(mod_name))
+            mod_obj.supported = supported
+            mod_obj.blacklisted = blacklisted
+
+            key = f"{mod_name}:{supported}"
             if cs not in report[key]:
                 report[key].append(cs)
 
@@ -230,7 +238,7 @@ def print_kmodules(report):
     for key, cs_list in report.items():
         cs = cs_list[0]
         m = key.split(':')[0]
-        supported = cs.modules[m]
+        supported = cs.modules[m].supported
         cs_str = utils.classify_codestreams_str(cs_list)
         logging.info("%s:\nMOD: %s\nSupported: %s\n",
                      cs_str, m, supported)
@@ -244,12 +252,17 @@ def filter_unsupported_kmodules(cs_list):
         if not cs.modules:
             continue
 
-        supported = [s for _, s in cs.modules.items() if s]
-        if not supported:
+        # A module is "supported" iff its klp-build supportedness flag is True
+        # (None / False are not).
+        if not any(m.supported for m in cs.modules.values()):
             unset_cs.append(cs)
 
-        # Cleanup for future re-use
-        cs.modules.clear()
+        # NOTE: previously cs.modules.clear() was called here to wipe the
+        # supportedness bools so the path-cache repopulation in
+        # setup.__setup_check_mod could reuse the dict. With AffectedModule the
+        # supported/blacklisted flags and the per-arch obj-path cache are
+        # independent fields on the same object, so the wipe is no longer
+        # needed - and would in fact destroy state we want to keep.
 
     for cs in unset_cs:
         cs_list.remove(cs)

--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -13,12 +13,9 @@ import logging
 from pathlib import Path, PurePath
 from importlib import resources
 
-from pathlib import Path, PurePath
-from importlib import resources
-
-from klpbuild.klplib.config import get_user_path
+from klpbuild.klplib.affected_file import AffectedConfig, AffectedFile, AffectedModule, ConfigState
 from klpbuild.klplib.ksrc import ksrc_read_rpm_file, ksrc_is_module_supported
-from klpbuild.klplib.utils import ARCH, get_workdir, is_mod, get_elf_object, get_datadir, preferred_arch
+from klpbuild.klplib.utils import ARCH, get_workdir, get_elf_object, get_datadir, preferred_arch
 from klpbuild.klplib.kernel_tree import init_cs_kernel_tree, file_exists_in_tag, read_file_in_tag
 from klpbuild.klplib.ksrc import KERNEL_BRANCHES
 
@@ -52,11 +49,69 @@ class Codestream:
         self.eol = eol
 
         self.archs = set(archs) if archs is not None else self.get_default_archs()
-        self.files = files if files is not None else {}
-        self.modules = modules if modules is not None else {}
-        self.configs = configs if configs is not None else {}
+        self.files = self.__build_files(files)
+        self.modules = self.__build_modules(modules)
+        self.configs = self.__build_configs(configs)
 
         self.required_patches = required_patches if required_patches is not None else []
+
+    @staticmethod
+    def __build_configs(configs):
+        """
+        Normalise the ``configs`` constructor argument to ``dict[str, AffectedConfig]``.
+
+        Accepts ``None``, a ``dict[str, AffectedConfig]`` (passed through as-is),
+        or the JSON shape ``dict[str, dict[arch, 'y'|'m']]`` produced by
+        :meth:`AffectedConfig.to_dict` (for round-tripping through ``to_data``
+        / ``from_data``).
+        """
+        if not configs:
+            return {}
+        out = {}
+        for name, value in configs.items():
+            if isinstance(value, AffectedConfig):
+                out[name] = value
+            else:
+                out[name] = AffectedConfig.from_dict(name, value)
+        return out
+
+    @staticmethod
+    def __build_files(files):
+        """
+        Normalise the ``files`` constructor argument to ``dict[str, AffectedFile]``.
+
+        Accepts ``None``, a ``dict[str, AffectedFile]`` (passed through as-is),
+        or the JSON shape produced by :meth:`AffectedFile.to_dict` (for
+        round-tripping through ``to_data`` / ``from_data``).
+        """
+        if not files:
+            return {}
+        out = {}
+        for name, value in files.items():
+            if isinstance(value, AffectedFile):
+                out[name] = value
+            else:
+                out[name] = AffectedFile.from_dict(name, value)
+        return out
+
+    @staticmethod
+    def __build_modules(modules):
+        """
+        Normalise the ``modules`` constructor argument to ``dict[str, AffectedModule]``.
+
+        Accepts ``None``, a ``dict[str, AffectedModule]`` (passed through as-is),
+        or the JSON shape produced by :meth:`AffectedModule.to_dict` (for
+        round-tripping through ``to_data`` / ``from_data``).
+        """
+        if not modules:
+            return {}
+        out = {}
+        for name, value in modules.items():
+            if isinstance(value, AffectedModule):
+                out[name] = value
+            else:
+                out[name] = AffectedModule.from_dict(name, value)
+        return out
 
 
     @classmethod
@@ -74,9 +129,9 @@ class Codestream:
                 "kernel" : self.kernel,
                 "eol" : self.eol,
                 "archs": list(self.archs),
-                "files" : self.files,
-                "modules" : self.modules,
-                "configs" : self.configs,
+                "files" : {n: f.to_dict() for n, f in self.files.items()},
+                "modules" : {n: m.to_dict() for n, m in self.modules.items()},
+                "configs" : {n: c.to_dict() for n, c in self.configs.items()},
                 "required_patches" : self.required_patches
                 }
 
@@ -218,7 +273,7 @@ class Codestream:
         return {"ppc64le", "s390x", "x86_64"}
 
     def set_files(self, files):
-        self.files = files
+        self.files = self.__build_files(files)
 
     def set_configs(self, configs):
         self.configs = {conf: self.get_all_configs(conf) for conf in configs}
@@ -366,20 +421,33 @@ class Codestream:
 
         return get_datadir(arch)/mod_path/"modules"/self.get_full_kernel_name()
 
-    # A codestream can be patching multiple objects, so get the path related to
-    # the module that we are interested
-    def get_mod(self, mod):
-        return self.modules[mod]
+    # A codestream can be patching multiple objects; look up the AffectedModule
+    # by its bare name (e.g. "vmlinux" or "fs/ext4/ext4").
+    def get_mod(self, mod_name):
+        return self.modules[mod_name]
 
 
     def get_file_mod(self, file, arch=None):
+        """
+        Resolve which kernel object the given file is patched into for ``arch``.
+
+        Returns an :class:`AffectedModule` (the codestream's vmlinux singleton
+        when the gating CONFIG is built-in on ``arch``, the designated
+        ``module_name`` entry otherwise). The returned instance is the same one
+        held in :attr:`modules`, so any subsequent path-cache or supportedness
+        updates persist on the codestream.
+        """
         fdat = self.files[file]
 
         if not arch:
             arch = preferred_arch([self])
 
-        conf_arch = self.configs[fdat["conf"]][arch]
-        return "vmlinux" if conf_arch == 'y' else fdat["module"]
+        cfg = self.configs[fdat.config_name]
+        if cfg.get_arch(arch) is ConfigState.BUILTIN:
+            return self.modules.setdefault(AffectedModule.VMLINUX,
+                                           AffectedModule.vmlinux())
+        return self.modules.setdefault(fdat.module_name,
+                                       AffectedModule(fdat.module_name))
 
 
     def is_module_supported(self, mod):
@@ -392,23 +460,25 @@ class Codestream:
 
     def get_all_configs(self, conf):
         """
-        Get the config value for all supported architectures of a codestream. If
-        the configuration is not set the return value will be an empty dict.
-        """
-        configs = {}
+        Get the config value for all supported architectures of a codestream.
 
+        Returns an :class:`AffectedConfig`. Architectures where the config is
+        unset (or absent from the kernel config) report as
+        :attr:`ConfigState.NOT_SET` via :meth:`AffectedConfig.get_arch`.
+        """
         if conf and not conf.startswith("CONFIG_"):
             logging.error("Invalid config '%s': Missing CONFIG_ prefix", conf)
             sys.exit(1)
 
+        cfg = AffectedConfig(conf)
         for arch in self.archs:
             kconf = self.get_config_content(arch)
 
             match = re.search(rf"{conf}=([ym])", kconf)
             if match:
-                configs[arch] = match.group(1)
+                cfg.set_arch(arch, ConfigState(match.group(1)))
 
-        return configs
+        return cfg
 
     def get_mod_file_path(self, arch, mod):
         """
@@ -448,17 +518,24 @@ class Codestream:
         return file_path[0]
 
     def find_obj_path(self, arch, mod):
-        # Return the path if the modules was previously found for ARCH, or refetch if
-        # the obejct is for a different architecture
-        if is_mod(mod):
-            obj = self.modules.get(mod, "")
-            if obj:
-                assert self.kernel in str(obj)
-                return obj
+        """
+        Resolve the on-disk object path for ``mod`` (a bare module name, e.g.
+        ``"fs/ext4/ext4"`` or ``"vmlinux"``) on ``arch``, caching the result
+        per-arch on the corresponding :class:`AffectedModule` to avoid
+        re-scanning the filesystem on subsequent calls.
+        """
+        is_vmlinux = mod == AffectedModule.VMLINUX
+        mod_obj = self.modules.setdefault(
+            mod,
+            AffectedModule.vmlinux() if is_vmlinux else AffectedModule(mod),
+        )
 
-        # If the module cache failed or if mod is vmlinux, we need to find the
-        # path to the object
-        if not is_mod(mod):
+        cached = mod_obj.get_obj_path(arch)
+        if cached:
+            assert self.kernel in cached
+            return cached
+
+        if is_vmlinux:
             fpath = Path(self.get_boot_dir(arch), self.get_boot_filename("vmlinux"))
         else:
             fpath = Path(self.get_mod_path(arch), self.get_mod_file_path(arch, mod))
@@ -467,7 +544,9 @@ class Codestream:
 
         assert fmod.exists(), f"Module {str(fmod)} doesn't exists. Aborting"
 
-        return fmod.relative_to(get_datadir(arch))
+        resolved = fmod.relative_to(get_datadir(arch))
+        mod_obj.set_obj_path(arch, str(resolved))
+        return resolved
 
     def lp_out_file(self, lp_name, fname):
         fpath = f'{str(fname).replace("/", "_").replace("-", "_")}'
@@ -541,7 +620,7 @@ class Codestream:
         trace_addrs = []
 
         # Get the addresses of the traceable objects on vmlinux
-        if not is_mod(mod) and check_patchable:
+        if mod == AffectedModule.VMLINUX and check_patchable:
             trace_addrs = self.__get_trace_addresses(arch, elf_obj)
 
         symtab = elf_obj.get_section_by_name(".symtab")

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -7,6 +7,7 @@ import logging
 import shutil
 from pathlib import Path
 
+from klpbuild.klplib.affected_file import AffectedModule
 from klpbuild.klplib.utils import classify_codestreams_str,ARCHS
 from klpbuild.klplib.ibs import download_cs_rpms, verify_rpm
 from klpbuild.klplib.config import get_user_path
@@ -114,7 +115,7 @@ def __cs_is_missing_data(cs):
     '''
     for arch in cs.archs:
         try:
-            cs.find_obj_path(arch, "vmlinux")
+            cs.find_obj_path(arch, AffectedModule.VMLINUX)
         except AssertionError:
             # Assert triggered: vmlinux was not found
             return True

--- a/klpbuild/klplib/file2config.py
+++ b/klpbuild/klplib/file2config.py
@@ -9,11 +9,13 @@ import re
 
 from pathlib import Path
 
+from klpbuild.klplib.affected_file import AffectedModule, ConfigState
+
 
 archs_config = {
-        's390x': {'conf': "CONFIG_S390", 'module': 'vmlinux'},
-        'x86_64': {'conf': "CONFIG_X86_64", 'module': 'vmlinux'},
-        'ppc64le': {'conf': "CONFIG_PPC64", 'module': 'vmlinux'},
+        's390x': {'conf': "CONFIG_S390", 'module': AffectedModule.VMLINUX},
+        'x86_64': {'conf': "CONFIG_X86_64", 'module': AffectedModule.VMLINUX},
+        'ppc64le': {'conf': "CONFIG_PPC64", 'module': AffectedModule.VMLINUX},
 }
 
 
@@ -89,7 +91,7 @@ def _find_config(cs, base_dir, relative_obj_path, deep):
         return None, ""
 
     if Path(".") == base_dir:
-        return "CONFIG_SUSE_KERNEL", "vmlinux"
+        return "CONFIG_SUSE_KERNEL", AffectedModule.VMLINUX
 
     lines = _load_makefile(cs, Path(base_dir, "Kbuild"))
     if not lines:
@@ -207,8 +209,8 @@ def find_file_config(cs, path):
     # the given file path.
     elif path.startswith("arch"):
         arch = _get_arch_in_path(path)
-        archs = cs.get_all_configs(config)
-        if arch and (len(archs) != 1 or not archs.get(arch)):
+        cfg = cs.get_all_configs(config)
+        if arch and (len(cfg.archs()) != 1 or cfg.get_arch(arch) is ConfigState.NOT_SET):
             return archs_config[arch]['conf'], archs_config[arch]['module']
 
     if not config or not config.startswith('CONFIG_'):

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -21,6 +21,7 @@ from lxml import etree
 from natsort import natsorted
 from osctiny import Osc
 
+from klpbuild.klplib.affected_file import AffectedModule
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.config import get_user_settings
 from klpbuild.klplib.utils import ARCH, ARCHS, get_all_symbols_from_object, get_datadir
@@ -141,7 +142,7 @@ def get_cs_packages(cs_list, dest):
 
 
 def find_missing_symbols(cs, arch, lp_mod_path):
-    vmlinux_path = get_datadir(arch) / cs.find_obj_path(arch, "vmlinux")
+    vmlinux_path = get_datadir(arch) / cs.find_obj_path(arch, AffectedModule.VMLINUX)
     vmlinux_syms = get_all_symbols_from_object(vmlinux_path, True)
 
     # Get list of UNDEFINED symbols from the livepatch module

--- a/klpbuild/klplib/templ.py
+++ b/klpbuild/klplib/templ.py
@@ -12,8 +12,8 @@ from mako.template import Template
 from klpbuild.klplib.bugzilla import get_bug_title, get_bug
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.codestreams_data import get_codestreams_data
-from klpbuild.klplib.utils import (fix_mod_string, get_mail, get_workdir,
-                                   get_lp_number, get_fname, is_mod)
+from klpbuild.klplib.utils import (get_mail, get_workdir,
+                                   get_lp_number, get_fname)
 
 
 MACRO_PROTO_SYMS = """\
@@ -397,23 +397,20 @@ ${get_entries(lpdir, bsc, cs)}
 
 TEMPL_PATCHED = """\
 <%
-from klpbuild.klplib.utils import (is_mod,
-                                   fix_mod_string)
 def get_patched(cs, check_enabled):
     ret = []
     for ffile, fdata in cs.files.items():
         conf = ''
-        if check_enabled and fdata['conf']:
-            conf = f' IS_ENABLED({fdata["conf"]})'
+        if check_enabled and fdata.config_name:
+            conf = f' IS_ENABLED({fdata.config_name})'
 
         mod = cs.get_file_mod(ffile)
-        if is_mod(mod):
-            mod = fix_mod_string(mod)
+        mod_str = mod.lp_module_name
 
-        syms = list(fdata['klpp_symbols'].keys())
+        syms = list(fdata.klpp_symbols.keys())
         syms.sort()
         for sym in syms:
-            ret.append(f'{mod} {sym} klpp_{sym}{conf}')
+            ret.append(f'{mod_str} {sym} klpp_{sym}{conf}')
 
     return "\\n".join(ret)
 %>\
@@ -433,12 +430,12 @@ def get_multi_funcs(cs, lp_name):
     cleanups = []
 
     for file, dat in cs.files.items():
-        if not dat["ext_symbols"]:
+        if not dat.ext_symbols:
             continue
 
         fname = get_fname(cs.lp_out_file(lp_name, file))
         mod = cs.get_file_mod(file)
-        cln = f"\t{fname}_cleanup();\n" if is_mod(mod) else ''
+        cln = f"\t{fname}_cleanup();\n" if not mod.is_vmlinux else ''
         init = f"\tret = {fname}_init();\n\tif (ret)\n\t\treturn ret;\n"
 
         inits.append(init)
@@ -472,7 +469,7 @@ def __generate_klpp_header(cs):
     enums = set()
 
     for dat in cs.files.values():
-        protos = list(dat["klpp_symbols"].values())
+        protos = list(dat.klpp_symbols.values())
         funcs.extend(protos)
         for p in protos:
             structs.update(re.findall(r"(struct\s+\w+)\s*\**\w+", p))
@@ -509,17 +506,17 @@ def __generate_header_file(lp_name, lp_path, cs):
         proto_syms = {}
 
         for src_file, data in cs.files.items():
-            configs.add(data["conf"])
+            configs.add(data.config_name)
             mod = cs.get_file_mod(src_file)
             # If we have external symbols we need an init function to load them. If the module
             # isn't vmlinux then we also need an _exit function
-            if data["ext_symbols"]:
-                if is_mod(mod):
+            if data.ext_symbols:
+                if not mod.is_vmlinux:
                     # Used by the livepatch_cleanup
                     has_cleanup = True
 
                 proto_fname = get_fname(cs.lp_out_file(lp_name, src_file))
-                proto_syms[proto_fname] = {"cleanup": is_mod(mod)}
+                proto_syms[proto_fname] = {"cleanup": not mod.is_vmlinux}
 
         # If we don't have any external symbols then we don't need the empty _init/_exit functions
         if proto_syms.keys():
@@ -588,11 +585,11 @@ def __generate_lp_file(lp_name, lp_path, cs, src_file, out_name):
         fdata = cs.files[str(src_file)]
         mod = cs.get_file_mod(src_file)
         tvars.update({
-            "config": fdata.get("conf", ""),
-            "ext_vars": fdata.get("ext_symbols", ""),
-            "ibt": fdata.get("ibt", False),
+            "config": fdata.config_name or "",
+            "ext_vars": fdata.ext_symbols,
+            "ibt": fdata.ibt,
             "inc_src_file": cs.lp_out_file(lp_name, src_file),
-            "mod": fix_mod_string(mod),
+            "mod": "" if mod.is_vmlinux else mod.lp_module_name,
             "mod_mutex": cs.is_mod_mutex(),
         })
 

--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -121,10 +121,6 @@ def unclassify_codestreams(cs_group, cs_list):
     return [cs for cs in cs_list if cs.full_cs_name() in expanded]
 
 
-def is_mod(mod):
-    return mod != "vmlinux"
-
-
 def get_lp_number(lp_name):
     return lp_name.replace("bsc", "")
 
@@ -355,8 +351,8 @@ def filter_codestreams_by_arch(archs, cs_list):
 def affected_archs(cs_list):
     conf_archs = set()
     for cs in cs_list:
-        for val in cs.configs.values():
-            conf_archs.update(val)
+        for cfg in cs.configs.values():
+            conf_archs.update(cfg.archs())
 
     return sorted(conf_archs)
 
@@ -384,14 +380,6 @@ def get_mail():
     email = git_data.get_value("user", "email")
 
     return user, email
-
-def fix_mod_string(mod):
-    if not is_mod(mod):
-        return ""
-
-    # Modules like snd-pcm needs to be replaced by snd_pcm in LP_MODULE
-    # and in kallsyms lookup
-    return os.path.basename(mod.replace("-", "_"))
 
 
 def get_fname(src_name):

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -21,6 +21,7 @@ from filelock import FileLock
 from natsort import natsorted
 
 from klpbuild.klplib import utils
+from klpbuild.klplib.affected_file import AffectedFile, AffectedModule
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
 from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_list
 from klpbuild.klplib.config import get_user_settings
@@ -226,7 +227,7 @@ def get_missing_ext_symbols(working_cs):
         # only once per object
         obj_syms = {}
         for fdata in cs.files.values():
-            for obj, syms in fdata["ext_symbols"].items():
+            for obj, syms in fdata.ext_symbols.items():
                 obj_syms.setdefault(obj, [])
                 obj_syms[obj].extend(syms)
 
@@ -247,7 +248,7 @@ def get_missing_ext_symbols(working_cs):
     return missing_syms, unext_syms
 
 
-def fix_ext_symbols(cs, lp_dat, lp_out):
+def fix_ext_symbols(cs, fdata: AffectedFile, lp_out):
     '''
     Fix klp-ccp mistakes on non-ibt livepatches:
         - Drop any duplicated externalized symbol declaration generated
@@ -261,7 +262,7 @@ def fix_ext_symbols(cs, lp_dat, lp_out):
     if cs.needs_ibt():
         return lp_out
 
-    for sym_list in lp_dat["ext_symbols"].values():
+    for sym_list in fdata.ext_symbols.values():
         for s in sym_list:
             # Keep only static declarations
             lp_out = re.sub(rf"^(?!static|\s|#)\w[^;:()=]+\(\*klpe_{s}\)[^;:=]*;",
@@ -299,8 +300,6 @@ def get_ext_symbols(out_dir):
                 _, sym, var, mod = l.split(" ")
                 # Module names should not use dashes
                 mod = mod.replace("-", "_")
-                if not utils.is_mod(mod):
-                    mod = "vmlinux"
 
                 exts.append((sym, var, mod))
 
@@ -586,7 +585,7 @@ def apply_all_patches(lp_name, cs):
 def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
     lp_out = Path(out_dir, cs.lp_out_file(lp_name, fname))
 
-    funcs = ",".join(fdata["symbols"])
+    funcs = ",".join(sorted(fdata.affected_symbols))
 
     ccp_args = [str(shutil.which("klp-ccp")), "-P", "suse.KlpPolicy",
                 "--compiler=x86_64-gcc-9.1.0", "-i", f"{funcs}", "-o",
@@ -632,12 +631,18 @@ def cmd_args(lp_name, cs, fname, out_dir, fdata, cmd, avoid_ext):
 
     # Needed, otherwise threads would interfere with each other
     env = os.environ.copy()
-    obj = cs.get_file_mod(fname)
+    arch = utils.preferred_arch([cs])
+    obj = cs.get_file_mod(fname, arch)
+
+    # ``find_obj_path`` resolves and caches the per-arch path on ``obj``; we
+    # rely on the path having been populated earlier (during setup), but call
+    # it here as a safety net so a missing cache entry does not crash.
+    obj_path = obj.get_obj_path(arch) or str(cs.find_obj_path(arch, obj.name))
 
     env["KCP_KLP_CONVERT_EXTS"] = "1" if cs.needs_ibt() else "0"
     env["KCP_MOD_SYMVERS"] = str(Path(cs.get_boot_dir(), f'{cs.get_boot_filename("symvers")}.gz'))
     env["KCP_KBUILD_ODIR"] = str(cs.get_obj_dir())
-    env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(utils.preferred_arch([cs]))/cs.get_mod(obj))
+    env["KCP_PATCHED_OBJ"] = str(utils.get_datadir(arch) / obj_path)
     env["KCP_KBUILD_SDIR"] = str(cs.get_src_dir())
     env["KCP_IPA_CLONES_DUMP"] = str(cs.get_ipa_file(fname))
     env["KCP_WORK_DIR"] = str(out_dir)
@@ -711,8 +716,7 @@ def _warn_ipa_removed(match, cs, fname):
 
 
 def _collect_dup_symbol(match, cs, fname):
-    cs.files[fname].setdefault("dup_symbols", [])
-    cs.files[fname]["dup_symbols"].append(match.group(1))
+    cs.files[fname].dup_symbols.append(match.group(1))
 
 
 CCP_WARNING_SPECS = [
@@ -761,7 +765,7 @@ def process(lp_name, total, args, avoid_ext):
 
     # Detect and set ibt information. It will be used in the TemplateGen
     if '-fcf-protection' in cmd or cs.needs_ibt():
-        cs.files[fname]["ibt"] = True
+        cs.files[fname].ibt = True
 
     out_log = Path(out_dir, "ccp.out.txt")
     with open(out_log, "w+") as f:
@@ -781,13 +785,13 @@ def process(lp_name, total, args, avoid_ext):
 
     lp_out = Path(out_dir, cs.lp_out_file(lp_name, fname))
 
-    cs.files[fname]["ext_symbols"] = get_ext_symbols(out_dir)
-    cs.files[fname]["klpp_symbols"] = get_klpp_symbols(out_dir, lp_out)
+    cs.files[fname].ext_symbols = get_ext_symbols(out_dir)
+    cs.files[fname].klpp_symbols = get_klpp_symbols(out_dir, lp_out)
 
     lp_out_cleanup(cs, cs.files[fname], lp_out, sdir)
 
 
-def lp_out_cleanup(cs, lp_dat, lp_out, sdir):
+def lp_out_cleanup(cs, fdata: AffectedFile, lp_out, sdir):
     """
     Open the file, read, seek to the beginning, write the new data, and
     then truncate (which will use the current position in file as the
@@ -810,7 +814,7 @@ def lp_out_cleanup(cs, lp_dat, lp_out, sdir):
         file_buf = re.sub(fr"#include \"{str(sdir)}.*\.h\"", '', file_buf)
         file_buf = re.sub(fr"#define\s({macros}).*", '', file_buf)
         file_buf = re.sub(r" __(init|exit)", ' ', file_buf)
-        file_buf = fix_ext_symbols(cs, lp_dat, file_buf)
+        file_buf = fix_ext_symbols(cs, fdata, file_buf)
         file_buf = re.sub(r'\n{3,}', r'\n', file_buf)
         f.write(file_buf)
         f.truncate()
@@ -880,10 +884,10 @@ def start_extract(lp_name, lp_filter, no_patches, avoid_ext):
     # Check for duplicated symbols spotted by klp-ccp
     for cs in working_cs:
         for f, fdata in cs.files.items():
-            if fdata.get("dup_symbols"):
+            if fdata.dup_symbols:
                 logging.warning("%s:%s: Duplicated symbols (check the sympos):",
                                 cs.full_cs_name(), f)
-                logging.warning("\t%s", ", ".join(fdata.get("dup_symbols")))
+                logging.warning("\t%s", ", ".join(fdata.dup_symbols))
 
     logging.info("\nChecking the externalized symbols in other architectures...")
 

--- a/klpbuild/plugins/format_patches.py
+++ b/klpbuild/plugins/format_patches.py
@@ -139,9 +139,9 @@ def generate_groups(lp_name, codestreams):
         groups += f" - {group}\n"
         cs = cs_list[0]
         for file, fdat in cs.files.items():
-            if 'klpp_symbols' not in fdat:
+            if not fdat.klpp_symbols:
                 continue
-            syms = '\n\t\t   '.join(sorted(fdat['klpp_symbols']))
+            syms = '\n\t\t   '.join(sorted(fdat.klpp_symbols))
             mod = cs.get_file_mod(file)
             groups += f"\t* File: {file}\n\t* Module: {mod}\n"\
                       f"\t* Symbols: {syms}\n"

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -9,6 +9,7 @@ import logging
 from natsort import natsorted
 
 from klpbuild.klplib import bugzilla, utils
+from klpbuild.klplib.affected_file import AffectedFile
 from klpbuild.klplib.cmd import add_arg_lp_filter, add_arg_lp_name
 from klpbuild.klplib.codestreams_data import (
     get_codestreams_data,
@@ -126,14 +127,18 @@ def setup_manual(codestreams, archs, conf, mod,
         filepath = f[0]
         funcs = f[1:]
 
-        ffuncs[filepath] = {"module": mod, "conf": conf, "symbols": funcs}
+        ffuncs[filepath] = AffectedFile(filepath, config_name=conf,
+                                        module_name=mod,
+                                        affected_symbols=set(funcs))
 
     for f in mod_file_funcs:
         fmod = f[0]
         filepath = f[1]
         funcs = f[2:]
 
-        ffuncs[filepath] = {"module": fmod, "conf": conf, "symbols": funcs}
+        ffuncs[filepath] = AffectedFile(filepath, config_name=conf,
+                                        module_name=fmod,
+                                        affected_symbols=set(funcs))
 
     for f in conf_mod_file_funcs:
         fconf = f[0]
@@ -143,7 +148,9 @@ def setup_manual(codestreams, archs, conf, mod,
 
         configs.add(fconf)
 
-        ffuncs[filepath] = {"module": fmod, "conf": fconf, "symbols": funcs}
+        ffuncs[filepath] = AffectedFile(filepath, config_name=fconf,
+                                        module_name=fmod,
+                                        affected_symbols=set(funcs))
 
     for cs in codestreams:
         cs.set_archs(archs)
@@ -208,9 +215,9 @@ def setup_project_files(lp_name, codestreams, full_checks):
 
         # Check if the files and symbols exist in the respective codestream directories
         for f, fdata in cs.files.copy().items():
-            conf = fdata["conf"]
-            archs = cs.configs[conf]
-            syms = fdata["symbols"]
+            cfg = cs.configs[fdata.config_name]
+            archs = cfg.archs()
+            syms = fdata.affected_symbols
             if not syms:
                 logging.warning("%s (%s): No symbols found for %s file."
                                 " Skipping.", cs.full_cs_name(), cs.kernel, f)
@@ -227,18 +234,22 @@ def setup_project_files(lp_name, codestreams, full_checks):
                 mod = cs.get_file_mod(f, arch)
                 __setup_check_mod(cs, mod, arch)
 
-            # append the current symbols and module to anuy previously set ones
-            mod_info = syms_to_be_checked.get(mod, {})
-            syms_to_be_checked[mod] = {
-                "syms": mod_info.get("syms", []) + syms,
-                "archs": mod_info.get("archs", []) + list(archs.keys()),
+            # append the current symbols and module to any previously set ones.
+            # Key by the module's bare name (not the AffectedModule itself) so
+            # the downstream check_symbol_archs / find_obj_path chain keeps its
+            # string contract (matching the extract.py call site).
+            mod_name = mod.name
+            mod_info = syms_to_be_checked.get(mod_name, {})
+            syms_to_be_checked[mod_name] = {
+                "syms": mod_info.get("syms", []) + list(syms),
+                "archs": mod_info.get("archs", []) + list(archs),
             }
 
         # Just call the symbol check once per module
         # The set calls are necessary because we can have duplicated entries
         # like the arch for different files.
-        for mod, mod_info in syms_to_be_checked.items():
-            __symbol_check(cs, mod, set(mod_info["syms"]), set(mod_info["archs"]), full_checks)
+        for mod_name, mod_info in syms_to_be_checked.items():
+            __symbol_check(cs, mod_name, set(mod_info["syms"]), set(mod_info["archs"]), full_checks)
 
         if not cs.files:
             logging.error(f"%s (%s): No files eligible to be livepatched.", cs.full_cs_name(), cs.kernel)
@@ -262,17 +273,19 @@ def __setup_check_file(cs, file):
 
 
 def __setup_check_mod(cs, mod, arch):
-    if mod in cs.modules:
+    # ``mod`` is an :class:`AffectedModule` returned by ``cs.get_file_mod()``.
+    # Skip if the on-disk path is already cached for this arch on this object;
+    # ``find_obj_path`` will populate the cache and the supportedness check
+    # only needs to fire once per (codestream, module, arch) tuple.
+    if mod.get_obj_path(arch):
         return
 
-    mod_path = cs.find_obj_path(arch, mod)
+    mod_path = cs.find_obj_path(arch, mod.name)
 
     # Validate if the module being livepatched is supported or not
     if utils.check_module_unsupported(arch, mod_path):
         logging.warning("%s (%s): Module %s is not supported by SLE",
-                        cs.full_cs_name(), cs.kernel, mod)
-
-    cs.modules[mod] = str(mod_path)
+                        cs.full_cs_name(), cs.kernel, mod.name)
 
 
 def __symbol_check(cs, mod, syms, archs, full_checks):

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -106,7 +106,7 @@ def run(lp_name, lp_filter, no_check, archs, cve, conf, module, file_funcs,
                                               "archs": archs,
                                               "extra_patches": add_patches})
 
-    if conf:
+    if conf or conf_mod_file_funcs:
         setup_manual(codestreams, archs, conf, module,
                      file_funcs, mod_file_funcs,
                      conf_mod_file_funcs)
@@ -122,10 +122,12 @@ def setup_manual(codestreams, archs, conf, mod,
         raise ValueError("You need to specify at least one of the file-funcs variants!")
 
     ffuncs = {}
-    configs = {conf}
+    configs = set()
     for f in file_funcs:
         filepath = f[0]
         funcs = f[1:]
+
+        configs.add(conf)
 
         ffuncs[filepath] = AffectedFile(filepath, config_name=conf,
                                         module_name=mod,
@@ -135,6 +137,8 @@ def setup_manual(codestreams, archs, conf, mod,
         fmod = f[0]
         filepath = f[1]
         funcs = f[2:]
+
+        configs.add(conf)
 
         ffuncs[filepath] = AffectedFile(filepath, config_name=conf,
                                         module_name=fmod,

--- a/tests/test_affected_file.py
+++ b/tests/test_affected_file.py
@@ -1,0 +1,628 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 SUSE
+# Author: Vincenzo Mezzela <vincenzo.mezzela@suse.com>
+
+import pytest
+
+from klpbuild.klplib.affected_file import (
+    AffectedConfig,
+    AffectedFile,
+    AffectedModule,
+    ConfigState,
+)
+
+
+def test_config_state_values():
+    assert ConfigState.NOT_SET.value == "n"
+    assert ConfigState.MODULE.value == "m"
+    assert ConfigState.BUILTIN.value == "y"
+
+
+def test_config_state_from_value():
+    assert ConfigState("n") is ConfigState.NOT_SET
+    assert ConfigState("m") is ConfigState.MODULE
+    assert ConfigState("y") is ConfigState.BUILTIN
+
+
+def test_config_state_invalid_value():
+    with pytest.raises(ValueError):
+        ConfigState("z")
+
+
+def test_config_init_requires_config_prefix():
+    with pytest.raises(ValueError, match=r"missing CONFIG_ prefix"):
+        AffectedConfig("FOO")
+
+
+def test_config_init_default_is_empty():
+    cfg = AffectedConfig("CONFIG_FOO")
+    assert cfg.config_name == "CONFIG_FOO"
+    assert cfg.archs() == set()
+    assert not cfg.is_set()
+
+
+def test_config_init_with_arch_values():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y", "ppc64le": "m"})
+    assert cfg.get_arch("x86_64") is ConfigState.BUILTIN
+    assert cfg.get_arch("ppc64le") is ConfigState.MODULE
+    assert cfg.get_arch("s390x") is ConfigState.NOT_SET
+
+
+def test_config_init_invalid_value_in_arch_values():
+    with pytest.raises(ValueError):
+        AffectedConfig("CONFIG_FOO", {"x86_64": "z"})
+
+
+def test_config_set_with_unknown_arch_raises():
+    cfg = AffectedConfig("CONFIG_FOO")
+    with pytest.raises(ValueError, match=r"Unknown arch"):
+        cfg.set_arch("bogus", ConfigState.BUILTIN)
+
+
+def test_config_set_not_set_removes_entry():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    assert "x86_64" in cfg.archs()
+    cfg.set_arch("x86_64", ConfigState.NOT_SET)
+    assert cfg.get_arch("x86_64") is ConfigState.NOT_SET
+    assert "x86_64" not in cfg.archs()
+
+
+def test_config_set_overwrites_existing_value():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    cfg.set_arch("x86_64", ConfigState.MODULE)
+    assert cfg.get_arch("x86_64") is ConfigState.MODULE
+
+
+def test_config_get_default_is_not_set():
+    cfg = AffectedConfig("CONFIG_FOO")
+    for arch in ("x86_64", "ppc64le", "s390x"):
+        assert cfg.get_arch(arch) is ConfigState.NOT_SET
+
+
+def test_config_get_with_unknown_arch_raises():
+    cfg = AffectedConfig("CONFIG_FOO")
+    with pytest.raises(ValueError, match=r"Unknown arch"):
+        cfg.get_arch("bogus")
+
+
+def test_config_archs_returns_only_set_archs():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y", "s390x": "m"})
+    assert cfg.archs() == {"x86_64", "s390x"}
+
+
+def test_config_is_builtin_on_any():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "m"})
+    assert not cfg.is_builtin_on_any()
+    cfg.set_arch("ppc64le", ConfigState.BUILTIN)
+    assert cfg.is_builtin_on_any()
+
+
+def test_config_is_module_on_any():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    assert not cfg.is_module_on_any()
+    cfg.set_arch("ppc64le", ConfigState.MODULE)
+    assert cfg.is_module_on_any()
+
+
+def test_config_is_set():
+    cfg = AffectedConfig("CONFIG_FOO")
+    assert not cfg.is_set()
+    cfg.set_arch("x86_64", ConfigState.BUILTIN)
+    assert cfg.is_set()
+    cfg.set_arch("x86_64", ConfigState.NOT_SET)
+    assert not cfg.is_set()
+
+
+def test_config_bool_matches_is_set():
+    cfg = AffectedConfig("CONFIG_FOO")
+    assert not bool(cfg)
+    cfg.set_arch("x86_64", ConfigState.BUILTIN)
+    assert bool(cfg)
+
+
+def test_config_equality():
+    a = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    b = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    c = AffectedConfig("CONFIG_FOO", {"x86_64": "m"})
+    d = AffectedConfig("CONFIG_BAR", {"x86_64": "y"})
+    assert a == b
+    assert a != c
+    assert a != d
+    assert a != "not-a-config"
+
+
+def test_config_hashable():
+    a = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    b = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    s = {a, b}
+    assert len(s) == 1
+
+
+def test_config_repr_contains_name_and_values():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    r = repr(cfg)
+    assert "CONFIG_FOO" in r
+    assert "x86_64" in r
+
+
+def test_config_str_with_values():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y"})
+    assert str(cfg) == "CONFIG_FOO(x86_64=y)"
+
+
+def test_config_str_empty():
+    cfg = AffectedConfig("CONFIG_FOO")
+    assert str(cfg) == "CONFIG_FOO(not set)"
+
+
+def test_config_to_dict():
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "y", "ppc64le": "m"})
+    assert cfg.to_dict() == {"x86_64": "y", "ppc64le": "m"}
+
+
+def test_config_to_dict_empty():
+    assert AffectedConfig("CONFIG_FOO").to_dict() == {}
+
+
+def test_config_from_dict_round_trip():
+    original = AffectedConfig("CONFIG_FOO", {"x86_64": "y", "s390x": "m"})
+    rebuilt = AffectedConfig.from_dict("CONFIG_FOO", original.to_dict())
+    assert original == rebuilt
+
+
+def test_config_from_dict_empty():
+    rebuilt = AffectedConfig.from_dict("CONFIG_FOO", {})
+    assert rebuilt == AffectedConfig("CONFIG_FOO")
+    assert not rebuilt.is_set()
+
+
+def test_module_init_defaults():
+    m = AffectedModule("fs/ext4/ext4")
+    assert m.name == "fs/ext4/ext4"
+    assert m.supported is None
+    assert m.blacklisted is False
+    assert m.get_obj_path("x86_64") is None
+
+
+def test_module_vmlinux_constant():
+    assert AffectedModule.VMLINUX == "vmlinux"
+
+
+def test_module_vmlinux_factory():
+    v = AffectedModule.vmlinux()
+    assert isinstance(v, AffectedModule)
+    assert v.name == AffectedModule.VMLINUX
+    assert v.is_vmlinux
+    # vmlinux is always patchable in the klp-build sense; the factory
+    # pre-marks supported=True so callers like filter_unsupported_kmodules
+    # behave correctly when a vmlinux entry lands in cs.modules.
+    assert v.supported is True
+
+
+def test_module_is_vmlinux_false_for_regular_module():
+    m = AffectedModule("fs/ext4/ext4")
+    assert not m.is_vmlinux
+
+
+def test_module_cache_obj_path_unknown_arch_raises():
+    m = AffectedModule("foo")
+    with pytest.raises(ValueError, match=r"Unknown arch"):
+        m.set_obj_path("bogus", "/some/path")
+
+
+def test_module_get_obj_path_unknown_arch_raises():
+    m = AffectedModule("foo")
+    with pytest.raises(ValueError, match=r"Unknown arch"):
+        m.get_obj_path("bogus")
+
+
+def test_module_cache_and_get_obj_path():
+    m = AffectedModule("foo")
+    m.set_obj_path("x86_64", "/path/x86")
+    m.set_obj_path("s390x", "/path/s390")
+    assert m.get_obj_path("x86_64") == "/path/x86"
+    assert m.get_obj_path("s390x") == "/path/s390"
+    assert m.get_obj_path("ppc64le") is None
+
+
+def test_module_cache_overwrites_per_arch():
+    m = AffectedModule("foo")
+    m.set_obj_path("x86_64", "/old")
+    m.set_obj_path("x86_64", "/new")
+    assert m.get_obj_path("x86_64") == "/new"
+
+
+def test_module_to_dict_minimal():
+    m = AffectedModule("foo")
+    assert m.to_dict() == {
+        "supported": None,
+        "blacklisted": False,
+        "obj_paths": {},
+    }
+
+
+def test_module_to_dict_populated():
+    m = AffectedModule("foo")
+    m.supported = True
+    m.blacklisted = True
+    m.set_obj_path("x86_64", "/path/x86")
+    assert m.to_dict() == {
+        "supported": True,
+        "blacklisted": True,
+        "obj_paths": {"x86_64": "/path/x86"},
+    }
+
+
+def test_module_to_dict_obj_paths_is_a_copy():
+    m = AffectedModule("foo")
+    m.set_obj_path("x86_64", "/path/x86")
+    d = m.to_dict()
+    d["obj_paths"]["s390x"] = "/mutated"
+    # Internal state must remain untouched
+    assert m.get_obj_path("s390x") is None
+
+
+def test_module_from_dict_round_trip():
+    original = AffectedModule("foo")
+    original.supported = True
+    original.blacklisted = False
+    original.set_obj_path("x86_64", "/path/x86")
+    original.set_obj_path("s390x", "/path/s390")
+    rebuilt = AffectedModule.from_dict("foo", original.to_dict())
+    assert original == rebuilt
+    assert rebuilt.supported == original.supported
+    assert rebuilt.blacklisted == original.blacklisted
+    assert rebuilt.get_obj_path("x86_64") == "/path/x86"
+    assert rebuilt.get_obj_path("s390x") == "/path/s390"
+
+
+def test_module_from_dict_round_trip_minimal():
+    original = AffectedModule("foo")
+    rebuilt = AffectedModule.from_dict("foo", original.to_dict())
+    assert original == rebuilt
+    assert rebuilt.supported is None
+    assert rebuilt.blacklisted is False
+
+
+def test_module_from_dict_round_trip_vmlinux():
+    original = AffectedModule.vmlinux()
+    original.supported = True
+    original.set_obj_path("x86_64", "/boot/vmlinux-x86")
+    rebuilt = AffectedModule.from_dict(AffectedModule.VMLINUX, original.to_dict())
+    assert original == rebuilt
+    assert rebuilt.is_vmlinux
+    assert rebuilt.supported is True
+    assert rebuilt.get_obj_path("x86_64") == "/boot/vmlinux-x86"
+
+
+def test_module_from_dict_strict_missing_supported():
+    with pytest.raises(KeyError):
+        AffectedModule.from_dict("foo", {"blacklisted": False, "obj_paths": {}})
+
+
+def test_module_from_dict_strict_missing_blacklisted():
+    with pytest.raises(KeyError):
+        AffectedModule.from_dict("foo", {"supported": True, "obj_paths": {}})
+
+
+def test_module_from_dict_strict_missing_obj_paths():
+    with pytest.raises(KeyError):
+        AffectedModule.from_dict("foo", {"supported": True, "blacklisted": False})
+
+
+def test_module_from_dict_validates_arch_in_obj_paths():
+    with pytest.raises(ValueError, match=r"Unknown arch"):
+        AffectedModule.from_dict("foo", {
+            "supported": True,
+            "blacklisted": False,
+            "obj_paths": {"bogus": "/path"},
+        })
+
+
+def test_module_equality():
+    a = AffectedModule("foo")
+    b = AffectedModule("foo")
+    assert a == b
+    # __eq__ only compares name, so differing supported still means equal
+    b.supported = True
+    assert a == b
+    c = AffectedModule("bar")
+    assert a != c
+
+
+def test_module_equality_non_module_returns_not_implemented():
+    a = AffectedModule("foo")
+    assert a != "not-a-module"
+    assert a.__eq__("not-a-module") is NotImplemented
+
+
+def test_module_hashable():
+    a = AffectedModule("foo")
+    b = AffectedModule("foo")
+    s = {a, b}
+    assert len(s) == 1
+
+
+def test_module_str_returns_name():
+    m = AffectedModule("fs/ext4/ext4")
+    assert str(m) == "fs/ext4/ext4"
+    v = AffectedModule.vmlinux()
+    assert str(v) == "vmlinux"
+
+
+def test_module_repr_contains_name_and_state():
+    m = AffectedModule("fs/ext4/ext4")
+    m.supported = True
+    r = repr(m)
+    assert "fs/ext4/ext4" in r
+    assert "True" in r
+
+
+# Helper: a fully-populated dict matching AffectedFile.to_dict()'s schema, used
+# in strict-mode tests so they only differ from a valid input by the one key
+# being removed.
+_FILE_FULL_DICT = {
+    "config_name": "CONFIG_FOO",
+    "module_name": "drivers/foo",
+    "affected_symbols": ["a", "b"],
+    "ibt": False,
+    "dup_symbols": [],
+    "ext_symbols": {},
+    "klpp_symbols": {},
+}
+
+
+def test_file_init_defaults():
+    f = AffectedFile("foo.c")
+    assert f.filename == "foo.c"
+    assert f.config_name is None
+    assert f.module_name is None
+    assert f.affected_symbols == set()
+
+
+def test_file_init_extraction_defaults():
+    f = AffectedFile("foo.c")
+    assert f.ibt is False
+    assert f.dup_symbols == []
+    assert f.ext_symbols == {}
+    assert f.klpp_symbols == {}
+
+
+def test_file_extraction_attrs_assignable():
+    """Extract step writes these fields directly; verify they accept assignment."""
+    f = AffectedFile("foo.c")
+    f.ibt = True
+    f.dup_symbols.append("dup")
+    f.ext_symbols["mod"] = ["sym1", "sym2"]
+    f.klpp_symbols["sym1"] = "void sym1(void)"
+    assert f.ibt is True
+    assert f.dup_symbols == ["dup"]
+    assert f.ext_symbols == {"mod": ["sym1", "sym2"]}
+    assert f.klpp_symbols == {"sym1": "void sym1(void)"}
+
+
+def test_file_init_with_kwargs():
+    f = AffectedFile(
+        "fs/ext4/inode.c",
+        config_name="CONFIG_EXT4_FS",
+        module_name="fs/ext4/ext4",
+        affected_symbols={"a", "b"},
+    )
+    assert f.filename == "fs/ext4/inode.c"
+    assert f.config_name == "CONFIG_EXT4_FS"
+    assert f.module_name == "fs/ext4/ext4"
+    assert f.affected_symbols == {"a", "b"}
+
+
+def test_file_affected_symbols_is_a_copy():
+    src = {"a", "b"}
+    f = AffectedFile("foo.c", affected_symbols=src)
+    src.add("c")
+    # Mutating the source set must not leak into the AffectedFile
+    assert f.affected_symbols == {"a", "b"}
+
+
+def test_file_affected_symbols_accepts_iterable():
+    f = AffectedFile("foo.c", affected_symbols=("a", "b", "a"))
+    assert f.affected_symbols == {"a", "b"}
+
+
+def test_file_to_dict():
+    f = AffectedFile(
+        "foo.c",
+        config_name="CONFIG_FOO",
+        module_name="drivers/foo",
+        affected_symbols={"b", "a"},
+    )
+    assert f.to_dict() == {
+        "config_name": "CONFIG_FOO",
+        "module_name": "drivers/foo",
+        "affected_symbols": ["a", "b"],   # sorted
+        "ibt": False,
+        "dup_symbols": [],
+        "ext_symbols": {},
+        "klpp_symbols": {},
+    }
+
+
+def test_file_to_dict_defaults():
+    assert AffectedFile("foo.c").to_dict() == {
+        "config_name": None,
+        "module_name": None,
+        "affected_symbols": [],
+        "ibt": False,
+        "dup_symbols": [],
+        "ext_symbols": {},
+        "klpp_symbols": {},
+    }
+
+
+def test_file_to_dict_with_extraction_data():
+    f = AffectedFile("foo.c", config_name="CONFIG_FOO", module_name="drivers/foo")
+    f.ibt = True
+    f.dup_symbols = ["dup1", "dup2"]
+    f.ext_symbols = {"drivers/foo": ["bar", "baz"]}
+    f.klpp_symbols = {"bar": "int bar(void)"}
+    d = f.to_dict()
+    assert d["ibt"] is True
+    assert d["dup_symbols"] == ["dup1", "dup2"]
+    assert d["ext_symbols"] == {"drivers/foo": ["bar", "baz"]}
+    assert d["klpp_symbols"] == {"bar": "int bar(void)"}
+
+
+def test_file_to_dict_extraction_collections_are_copies():
+    """Mutating the dict returned by to_dict() must not affect internal state."""
+    f = AffectedFile("foo.c")
+    f.dup_symbols.append("a")
+    f.ext_symbols["mod"] = ["x"]
+    f.klpp_symbols["s"] = "p"
+    d = f.to_dict()
+    d["dup_symbols"].append("mutated")
+    d["ext_symbols"]["new_mod"] = []
+    d["klpp_symbols"]["new_sym"] = ""
+    assert f.dup_symbols == ["a"]
+    assert f.ext_symbols == {"mod": ["x"]}
+    assert f.klpp_symbols == {"s": "p"}
+
+
+def test_file_from_dict_round_trip():
+    original = AffectedFile(
+        "fs/ext4/inode.c",
+        config_name="CONFIG_EXT4_FS",
+        module_name="fs/ext4/ext4",
+        affected_symbols={"x", "y", "z"},
+    )
+    rebuilt = AffectedFile.from_dict("fs/ext4/inode.c", original.to_dict())
+    assert rebuilt.filename == original.filename
+    assert rebuilt.config_name == original.config_name
+    assert rebuilt.module_name == original.module_name
+    assert rebuilt.affected_symbols == original.affected_symbols
+    # Extraction-phase defaults round-trip too
+    assert rebuilt.ibt == original.ibt
+    assert rebuilt.dup_symbols == original.dup_symbols
+    assert rebuilt.ext_symbols == original.ext_symbols
+    assert rebuilt.klpp_symbols == original.klpp_symbols
+
+
+def test_file_from_dict_round_trip_defaults():
+    original = AffectedFile("foo.c")
+    rebuilt = AffectedFile.from_dict("foo.c", original.to_dict())
+    assert rebuilt.filename == original.filename
+    assert rebuilt.config_name is None
+    assert rebuilt.module_name is None
+    assert rebuilt.affected_symbols == set()
+    assert rebuilt.ibt is False
+    assert rebuilt.dup_symbols == []
+    assert rebuilt.ext_symbols == {}
+    assert rebuilt.klpp_symbols == {}
+
+
+def test_file_from_dict_round_trip_with_extraction():
+    original = AffectedFile(
+        "fs/ext4/inode.c",
+        config_name="CONFIG_EXT4_FS",
+        module_name="fs/ext4/ext4",
+        affected_symbols={"x"},
+    )
+    original.ibt = True
+    original.dup_symbols = ["dup_a", "dup_b"]
+    original.ext_symbols = {"fs/ext4/ext4": ["sym1", "sym2"]}
+    original.klpp_symbols = {"sym1": "int sym1(void)"}
+    rebuilt = AffectedFile.from_dict("fs/ext4/inode.c", original.to_dict())
+    assert rebuilt.ibt is True
+    assert rebuilt.dup_symbols == ["dup_a", "dup_b"]
+    assert rebuilt.ext_symbols == {"fs/ext4/ext4": ["sym1", "sym2"]}
+    assert rebuilt.klpp_symbols == {"sym1": "int sym1(void)"}
+
+
+def test_file_from_dict_strict_missing_config_name():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "config_name"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_module_name():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "module_name"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_affected_symbols():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "affected_symbols"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_ibt():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "ibt"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_dup_symbols():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "dup_symbols"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_ext_symbols():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "ext_symbols"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_strict_missing_klpp_symbols():
+    data = {k: v for k, v in _FILE_FULL_DICT.items() if k != "klpp_symbols"}
+    with pytest.raises(KeyError):
+        AffectedFile.from_dict("foo.c", data)
+
+
+def test_file_from_dict_rebuilds_set_from_list():
+    data = dict(_FILE_FULL_DICT)
+    data["affected_symbols"] = ["a", "b", "a"]
+    rebuilt = AffectedFile.from_dict("foo.c", data)
+    assert rebuilt.affected_symbols == {"a", "b"}
+
+
+def test_file_from_dict_extraction_collections_are_copies():
+    """from_dict must not retain references to the input dict's lists/dicts."""
+    src_dup = ["a"]
+    src_ext = {"mod": ["x"]}
+    src_klpp = {"s": "p"}
+    data = dict(_FILE_FULL_DICT)
+    data["dup_symbols"] = src_dup
+    data["ext_symbols"] = src_ext
+    data["klpp_symbols"] = src_klpp
+    rebuilt = AffectedFile.from_dict("foo.c", data)
+    src_dup.append("mutated")
+    src_ext["new_mod"] = []
+    src_klpp["new_sym"] = ""
+    assert rebuilt.dup_symbols == ["a"]
+    assert rebuilt.ext_symbols == {"mod": ["x"]}
+    assert rebuilt.klpp_symbols == {"s": "p"}
+
+
+def test_file_equality():
+    a = AffectedFile("foo.c", config_name="CONFIG_FOO")
+    b = AffectedFile("foo.c", config_name="CONFIG_BAR")
+    c = AffectedFile("bar.c", config_name="CONFIG_FOO")
+    assert a == b      # equality is filename-based
+    assert a != c
+    assert a != "not-a-file"
+    assert a.__eq__("not-a-file") is NotImplemented
+
+
+def test_file_hashable():
+    a = AffectedFile("foo.c")
+    b = AffectedFile("foo.c")
+    s = {a, b}
+    assert len(s) == 1
+
+
+def test_file_repr_contains_identity_and_keys():
+    f = AffectedFile("foo.c", config_name="CONFIG_FOO", module_name="drivers/foo")
+    r = repr(f)
+    assert "foo.c" in r
+    assert "CONFIG_FOO" in r
+    assert "drivers/foo" in r

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -5,11 +5,11 @@
 
 import logging
 
+from klpbuild.klplib.affected_file import AffectedConfig, AffectedFile, AffectedModule
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.kernel_tree import get_commit_body
 from klpbuild.klplib.analysis import (
     __extract_functions,
-    __get_arch_config,
     __analyse_cs_files,
     analyse_configs,
     analyse_kmodules,
@@ -188,21 +188,26 @@ def test_extract_functions_balanced_braces_in_body():
     assert __extract_functions([diff]) == {"braces"}
 
 
-# ── __get_arch_config ─────────────────────────────────────────────────────────
+# ── AffectedConfig.get_arch (replaces removed __get_arch_config) ──────────────
 
 def test_get_arch_config_existing():
-    assert __get_arch_config({"x86_64": "m", "s390x": "y"}, "x86_64") == "m"
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "m", "s390x": "y"})
+    assert cfg.get_arch("x86_64").value == "m"
 
 
 def test_get_arch_config_missing():
-    assert __get_arch_config({"x86_64": "m"}, "ppc64le") == "n"
+    cfg = AffectedConfig("CONFIG_FOO", {"x86_64": "m"})
+    assert cfg.get_arch("ppc64le").value == "n"
 
 
 # ── filter_unset_configs ──────────────────────────────────────────────────────
 
 def test_filter_unset_configs_removes_unset():
-    cs_set = FakeCS({}, configs={"CONFIG_A": {"x86_64": "m"}})
-    cs_unset = FakeCS({}, configs={"CONFIG_B": {}, "CONFIG_C": {}})
+    cs_set = FakeCS(configs={"CONFIG_A": AffectedConfig("CONFIG_A", {"x86_64": "m"})})
+    cs_unset = FakeCS(configs={
+        "CONFIG_B": AffectedConfig("CONFIG_B"),
+        "CONFIG_C": AffectedConfig("CONFIG_C"),
+    })
     cs_list = [cs_set, cs_unset]
     unset_cs, unset_conf = filter_unset_configs(cs_list)
     assert cs_unset in unset_cs
@@ -213,7 +218,7 @@ def test_filter_unset_configs_removes_unset():
 
 
 def test_filter_unset_configs_keeps_all_set():
-    cs = FakeCS({}, configs={"CONFIG_A": {"x86_64": "m"}})
+    cs = FakeCS(configs={"CONFIG_A": AffectedConfig("CONFIG_A", {"x86_64": "m"})})
     cs_list = [cs]
     unset_cs, unset_conf = filter_unset_configs(cs_list)
     assert not unset_cs
@@ -222,7 +227,7 @@ def test_filter_unset_configs_keeps_all_set():
 
 
 def test_filter_unset_configs_skips_empty_configs():
-    cs = FakeCS({}, configs={})
+    cs = FakeCS(configs={})
     cs_list = [cs]
     unset_cs, unset_conf = filter_unset_configs(cs_list)
     assert not unset_cs
@@ -230,8 +235,8 @@ def test_filter_unset_configs_skips_empty_configs():
 
 
 def test_filter_unset_configs_deduplicates_conf_names():
-    cs1 = FakeCS({}, cs_name="a", configs={"CONFIG_X": {}})
-    cs2 = FakeCS({}, cs_name="b", configs={"CONFIG_X": {}})
+    cs1 = FakeCS(cs_name="a", configs={"CONFIG_X": AffectedConfig("CONFIG_X")})
+    cs2 = FakeCS(cs_name="b", configs={"CONFIG_X": AffectedConfig("CONFIG_X")})
     cs_list = [cs1, cs2]
     _, unset_conf = filter_unset_configs(cs_list)
     assert unset_conf == ["CONFIG_X"]
@@ -239,8 +244,17 @@ def test_filter_unset_configs_deduplicates_conf_names():
 
 # ── filter_unsupported_kmodules ───────────────────────────────────────────────
 
+def _make_module(name, supported):
+    m = AffectedModule(name)
+    m.supported = supported
+    return m
+
+
 def test_filter_unsupported_kmodules_removes_unsupported():
-    cs = FakeCS({}, modules={"mod_a": False, "mod_b": False})
+    cs = FakeCS(modules={
+        "mod_a": _make_module("mod_a", False),
+        "mod_b": _make_module("mod_b", False),
+    })
     cs_list = [cs]
     unset = filter_unsupported_kmodules(cs_list)
     assert cs in unset
@@ -248,22 +262,23 @@ def test_filter_unsupported_kmodules_removes_unsupported():
 
 
 def test_filter_unsupported_kmodules_keeps_supported():
-    cs = FakeCS({}, modules={"mod_a": True})
+    cs = FakeCS(modules={"mod_a": _make_module("mod_a", True)})
     cs_list = [cs]
     unset = filter_unsupported_kmodules(cs_list)
     assert not unset
     assert cs in cs_list
 
 
-def test_filter_unsupported_kmodules_clears_modules():
-    cs = FakeCS({}, modules={"mod_a": True})
+def test_filter_unsupported_kmodules_preserves_modules():
+    cs = FakeCS(modules={"mod_a": _make_module("mod_a", True)})
     cs_list = [cs]
     filter_unsupported_kmodules(cs_list)
-    assert cs.modules == {}
+    assert "mod_a" in cs.modules
+    assert cs.modules["mod_a"].supported is True
 
 
 def test_filter_unsupported_kmodules_skips_no_modules():
-    cs = FakeCS({}, modules={})
+    cs = FakeCS(modules={})
     cs_list = [cs]
     unset = filter_unsupported_kmodules(cs_list)
     assert not unset
@@ -278,9 +293,9 @@ def test_analyse_cs_files_populates_files():
     report = __analyse_cs_files(cs, {"net/tls/tls_main.c": [diff]})
     assert "net/tls/tls_main.c" in cs.files
     entry = cs.files["net/tls/tls_main.c"]
-    assert entry["conf"]
-    assert entry["module"]
-    assert len(entry["symbols"]) > 0
+    assert entry.config_name
+    assert entry.module_name
+    assert len(entry.affected_symbols) > 0
     assert len(report) == 1
 
 
@@ -296,14 +311,14 @@ def test_analyse_cs_files_no_config_logs_warning(caplog):
 
 def test_analyse_configs_groups_by_config():
     cs1 = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net.o"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net.o")},
         cs_name="15.4u0",
-        configs={"CONFIG_NET": {"x86_64": "m"}},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "m"})},
     )
     cs2 = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net.o"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net.o")},
         cs_name="15.5u0",
-        configs={"CONFIG_NET": {"x86_64": "m"}},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "m"})},
     )
     report = analyse_configs([cs1, cs2])
     assert len(report) == 1
@@ -315,14 +330,14 @@ def test_analyse_configs_groups_by_config():
 
 def test_analyse_configs_separates_different_archs():
     cs1 = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net.o"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net.o")},
         cs_name="15.4u0",
-        configs={"CONFIG_NET": {"x86_64": "m"}},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "m"})},
     )
     cs2 = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net.o"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net.o")},
         cs_name="15.5u0",
-        configs={"CONFIG_NET": {"x86_64": "y"}},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "y"})},
     )
     report = analyse_configs([cs1, cs2])
     assert len(report) == 2
@@ -330,9 +345,9 @@ def test_analyse_configs_separates_different_archs():
 
 def test_analyse_configs_no_duplicate_cs_in_report():
     cs = FakeCS(
-        {"a.c": {"conf": "CONFIG_A", "module": "a.o"},
-         "b.c": {"conf": "CONFIG_A", "module": "b.o"}},
-        configs={"CONFIG_A": {"x86_64": "m"}},
+        {"a.c": AffectedFile("a.c", config_name="CONFIG_A", module_name="a.o"),
+         "b.c": AffectedFile("b.c", config_name="CONFIG_A", module_name="b.o")},
+        configs={"CONFIG_A": AffectedConfig("CONFIG_A", {"x86_64": "m"})},
     )
     report = analyse_configs([cs])
     key = list(report.keys())[0]
@@ -343,40 +358,43 @@ def test_analyse_configs_no_duplicate_cs_in_report():
 
 def test_analyse_kmodules_checks_module_support():
     cs = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net/core/net.o"}},
-        configs={"CONFIG_NET": {"x86_64": "m"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net/core/net.o")},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "m"})},
         supported={"net/core/net.o": (True, False)},
     )
     report = analyse_kmodules([cs])
     assert "net/core/net.o" in cs.modules
-    assert cs.modules["net/core/net.o"] is True
+    assert cs.modules["net/core/net.o"].supported is True
     assert len(report) == 1
 
 
 def test_analyse_kmodules_skips_builtin():
     cs = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net/core/net.o"}},
-        configs={"CONFIG_NET": {"x86_64": "y"}},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net/core/net.o")},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "y"})},
     )
     report = analyse_kmodules([cs])
     assert "net/core/net.o" not in cs.modules
     assert len(report) == 0
 
 
-def test_analyse_kmodules_skips_already_tracked():
+def test_analyse_kmodules_already_tracked_reuses_module():
     cs = FakeCS(
-        {"net.c": {"conf": "CONFIG_NET", "module": "net/core/net.o"}},
-        configs={"CONFIG_NET": {"x86_64": "m"}},
-        modules={"net/core/net.o": True},
+        {"net.c": AffectedFile("net.c", config_name="CONFIG_NET", module_name="net/core/net.o")},
+        configs={"CONFIG_NET": AffectedConfig("CONFIG_NET", {"x86_64": "m"})},
+        modules={"net/core/net.o": _make_module("net/core/net.o", True)},
     )
     report = analyse_kmodules([cs])
-    assert len(report) == 0
+    # The module is re-evaluated and reported (setdefault reuses the existing
+    # AffectedModule), so it appears in the report.
+    assert len(report) == 1
+    assert cs.modules["net/core/net.o"].supported is True
 
 
 def test_analyse_kmodules_warns_blacklisted(caplog):
     cs = FakeCS(
-        {"drv.c": {"conf": "CONFIG_DRV", "module": "drivers/drv.o"}},
-        configs={"CONFIG_DRV": {"x86_64": "m"}},
+        {"drv.c": AffectedFile("drv.c", config_name="CONFIG_DRV", module_name="drivers/drv.o")},
+        configs={"CONFIG_DRV": AffectedConfig("CONFIG_DRV", {"x86_64": "m"})},
         supported={"drivers/drv.o": (False, True)},
     )
     with caplog.at_level(logging.WARNING):

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -31,11 +31,13 @@ def test_find_obj_path_arch():
         ],
         "files": {
             "net/sched/sch_taprio.c": {
-                "module": "sch_taprio",
-                "conf": "CONFIG_NET_SCH_TAPRIO",
-                "symbols": [
+                "module_name": "sch_taprio",
+                "config_name": "CONFIG_NET_SCH_TAPRIO",
+                "affected_symbols": [
                         "taprio_change"
                 ],
+                "ibt": False,
+                "dup_symbols": [],
                 "ext_symbols": {
                     "sch_taprio": [
                         "advance_sched",
@@ -51,11 +53,24 @@ def test_find_obj_path_arch():
                         "taprio_policy",
                         "taprio_set_picos_per_byte"
                     ]
-                }
+                },
+                "klpp_symbols": {}
             }
         },
         "modules": {
-            "sch_taprio": "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko"
+            "sch_taprio": {
+                "supported": True,
+                "blacklisted": False,
+                "obj_paths": {
+                    # The bug this test guards against is find_obj_path
+                    # returning a path that contains the arch name (because
+                    # the cache used to be arch-blind). Cache the same
+                    # arch-relative path under each arch key.
+                    "x86_64":  "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko",
+                    "ppc64le": "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko",
+                    "s390x":   "lib/modules/5.14.21-150500.55.68-default/kernel/net/sched/sch_taprio.ko",
+                }
+            }
         },
         "repo": "SUSE_SLE-15-SP5_Update",
         "configs": {

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -11,6 +11,7 @@ import pytest
 
 import tests.utils as tests_utils
 from klpbuild.klplib import utils
+from klpbuild.klplib.affected_file import AffectedFile
 from klpbuild.klplib.codestream import Codestream
 from klpbuild.klplib.codestreams_data import load_codestreams
 from klpbuild.plugins.extract import (
@@ -23,6 +24,13 @@ from klpbuild.plugins.extract import (
 )
 from klpbuild.plugins.setup import run as setup
 from tests.utils import FakeCS
+
+
+def _make_fdata(ext_symbols=None):
+    """Create an AffectedFile with ext_symbols set for testing."""
+    f = AffectedFile("test.c")
+    f.ext_symbols = ext_symbols or {}
+    return f
 
 
 def test_get_klpp_symbols_missing_patched_funcs(tmp_path):
@@ -239,9 +247,9 @@ def test_detect_opt_clone(caplog):
 def test_fix_ext_symbols_ibt_returns_unchanged():
     """IBT codestreams bypass all fixups and return lp_out as-is."""
     cs = Codestream("15.6u0")  # needs_ibt() == True
-    lp_dat = {"ext_symbols": {"vmlinux": ["my_func"]}}
+    fdata = _make_fdata({"vmlinux": ["my_func"]})
     lp_out = "int (*klpe_my_func)(void);\nstatic int (*klpe_my_func)(void);\n"
-    assert fix_ext_symbols(cs, lp_dat, lp_out) == lp_out
+    assert fix_ext_symbols(cs, fdata, lp_out) == lp_out
 
 
 def test_fix_ext_symbols_removes_duplicate_non_static_decls():
@@ -251,13 +259,13 @@ def test_fix_ext_symbols_removes_duplicate_non_static_decls():
     declaration must survive intact.
     """
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["foo"]}}
+    fdata = _make_fdata({"vmlinux": ["foo"]})
     lp_out = (
         "int (*klpe_foo)(void);\n"   # duplicate #1 – must be removed
         "int (*klpe_foo)(void);\n"   # duplicate #2 – must be removed
         "static int (*klpe_foo)(void);\n"  # real declaration – must survive
     )
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert result.count("(*klpe_foo)") == 1
     assert "static int (*klpe_foo)(void);" in result
 
@@ -266,9 +274,9 @@ def test_fix_ext_symbols_hash_prefixed_line_not_removed():
     """Lines starting with '#' (e.g. macro definitions) are protected by the
     negative lookahead and must not be erased."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["foo"]}}
+    fdata = _make_fdata({"vmlinux": ["foo"]})
     lp_out = "#define WRAP int (*klpe_foo)(void);\n"
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "#define WRAP int (*klpe_foo)(void);" in result
 
 
@@ -276,9 +284,9 @@ def test_fix_ext_symbols_indented_decl_not_removed():
     """Declarations that start with whitespace (indented) are protected by the
     negative lookahead and must be left untouched."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["foo"]}}
+    fdata = _make_fdata({"vmlinux": ["foo"]})
     lp_out = "\tint (*klpe_foo)(void);\n"
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "(*klpe_foo)" in result
 
 
@@ -286,9 +294,9 @@ def test_fix_ext_symbols_symbol_name_is_exact():
     """The regex anchors on 'klpe_{sym}' exactly; a symbol whose name is a
     prefix of another must not accidentally remove the longer one."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["foo"]}}
+    fdata = _make_fdata({"vmlinux": ["foo"]})
     lp_out = "int (*klpe_foo)(void);\nint (*klpe_foobar)(void);\n"
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "(*klpe_foo)" not in result
     assert "(*klpe_foobar)" in result
 
@@ -297,18 +305,18 @@ def test_fix_ext_symbols_multi_word_type_removed():
     """Non-static declarations with multi-word types (e.g. 'unsigned long')
     are still matched and removed."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["counter"]}}
+    fdata = _make_fdata({"vmlinux": ["counter"]})
     lp_out = "unsigned long (*klpe_counter)(int x);\n"
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "(*klpe_counter)" not in result
 
 
 def test_fix_ext_symbols_multi_module_all_processed():
     """Symbols listed under different modules in ext_symbols are all cleaned up."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {"vmlinux": ["foo"], "nfnetlink": ["bar"]}}
+    fdata = _make_fdata({"vmlinux": ["foo"], "nfnetlink": ["bar"]})
     lp_out = "int (*klpe_foo)(void);\nint (*klpe_bar)(void);\n"
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "(*klpe_foo)" not in result
     assert "(*klpe_bar)" not in result
 
@@ -317,9 +325,9 @@ def test_fix_ext_symbols_percpu_scalar_type():
     """Percpu __attribute__ declaration with a scalar type is rewritten to
     'static TYPE __percpu VAR'."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {}}
+    fdata = _make_fdata({})
     lp_out = 'static __attribute__((section(".data..percpu" ""))) __typeof__(int) (*klpe_example);\n'
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "static int __percpu (*klpe_example);" in result
     assert "__attribute__" not in result
 
@@ -328,9 +336,9 @@ def test_fix_ext_symbols_percpu_struct_pointer_type():
     """Percpu __attribute__ declaration with a struct-pointer type is rewritten
     correctly; the full type including '*' ends up before __percpu."""
     cs = Codestream("15.4u0")
-    lp_dat = {"ext_symbols": {}}
+    fdata = _make_fdata({})
     lp_out = 'static __attribute__((section(".data..percpu" ""))) __typeof__(struct foo *) (*klpe_bar);\n'
-    result = fix_ext_symbols(cs, lp_dat, lp_out)
+    result = fix_ext_symbols(cs, fdata, lp_out)
     assert "static struct foo * __percpu (*klpe_bar);" in result
     assert "__attribute__" not in result
 
@@ -414,7 +422,7 @@ def _make_lp_out(tmp_path, content):
 def test_lp_out_cleanup_creates_orig_file(tmp_path):
     """A .orig backup is written next to the livepatch file."""
     lp_out = _make_lp_out(tmp_path, "content\n")
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
     assert (tmp_path / "livepatch.c.orig").exists()
 
 
@@ -422,7 +430,7 @@ def test_lp_out_cleanup_orig_preserves_original_content(tmp_path):
     """The .orig file contains the unmodified original content."""
     original = "static __init int foo(void) {}\n"
     lp_out = _make_lp_out(tmp_path, original)
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
     assert (tmp_path / "livepatch.c.orig").read_text() == original
 
 
@@ -430,7 +438,7 @@ def test_lp_out_cleanup_removes_local_path_from_comments(tmp_path):
     """'from {sdir}/' prefixes in klp-ccp comments are stripped."""
     sdir = tmp_path / "kernel"
     lp_out = _make_lp_out(tmp_path, f"/* klp-ccp: from {sdir}/drivers/net/foo.c */\n")
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, sdir)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, sdir)
     content = lp_out.read_text()
     assert str(sdir) not in content
     assert "from drivers/net/foo.c" in content
@@ -443,7 +451,7 @@ def test_lp_out_cleanup_removes_local_includes(tmp_path):
         tmp_path,
         f'#include "{sdir}/include/foo.h"\n#include <linux/module.h>\n',
     )
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, sdir)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, sdir)
     content = lp_out.read_text()
     assert f'#include "{sdir}' not in content
     assert "#include <linux/module.h>" in content
@@ -458,7 +466,7 @@ def test_lp_out_cleanup_removes_unsupported_macros(tmp_path):
         "#define KBUILD_MODNAME foo\n"
         "#define __seg_gs",
     )
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
     content = lp_out.read_text()
     assert "#define __KERNEL__" not in content
     assert "#define MODULE" not in content
@@ -469,14 +477,14 @@ def test_lp_out_cleanup_removes_unsupported_macros(tmp_path):
 def test_lp_out_cleanup_removes_init_exit_attributes(tmp_path):
     """' __init' and ' __exit' markers are removed from function signatures."""
     lp_out = _make_lp_out(tmp_path, "static __init int foo(void)\n{\n}\n")
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
     assert "__init" not in lp_out.read_text()
 
 
 def test_lp_out_cleanup_collapses_multiple_empty_lines(tmp_path):
     """Three or more consecutive blank lines are collapsed to one."""
     lp_out = _make_lp_out(tmp_path, "line1\n\n\n\nline2\n")
-    lp_out_cleanup(Codestream("15.4u0"), {"ext_symbols": {}}, lp_out, tmp_path)
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
     assert "\n\n\n" not in lp_out.read_text()
 
 
@@ -485,7 +493,7 @@ def test_lp_out_cleanup_collapses_multiple_empty_lines(tmp_path):
 def test_parse_ccp_warnings_optimized_clone(tmp_path, caplog):
     """Optimized-clone warning logs the clone name and a follow-up reminder."""
     fname = "net/bluetooth/l2cap_sock.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -502,7 +510,7 @@ def test_parse_ccp_warnings_optimized_clone(tmp_path, caplog):
 def test_parse_ccp_warnings_ipa_removed(tmp_path, caplog):
     """IPA-removed warning logs the symbol name."""
     fname = "kernel/sched/core.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -516,9 +524,9 @@ def test_parse_ccp_warnings_ipa_removed(tmp_path, caplog):
 
 
 def test_parse_ccp_warnings_dup_symbol(tmp_path):
-    """Conflicting-definition line appends the symbol to cs.files[fname]['dup_symbols']."""
+    """Conflicting-definition line appends the symbol to AffectedFile.dup_symbols."""
     fname = "net/ipv4/tcp_input.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -526,13 +534,13 @@ def test_parse_ccp_warnings_dup_symbol(tmp_path):
         f.write('conflicting definitions for symbol "sk_filter_trim_cap" found in ELF\n')
         parse_ccp_warnings(f, start_pos, cs, fname)
 
-    assert cs.files[fname]["dup_symbols"] == ["sk_filter_trim_cap"]
+    assert cs.files[fname].dup_symbols == ["sk_filter_trim_cap"]
 
 
 def test_parse_ccp_warnings_no_warnings(tmp_path, caplog):
     """Non-matching lines produce no log output and no side effects."""
     fname = "fs/ext4/inode.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -544,13 +552,15 @@ def test_parse_ccp_warnings_no_warnings(tmp_path, caplog):
             parse_ccp_warnings(f, start_pos, cs, fname)
 
     assert caplog.text == ""
-    assert "dup_symbols" not in cs.files[fname]
+    # AffectedFile.dup_symbols is always present (default []); no warning
+    # handler should have appended anything.
+    assert cs.files[fname].dup_symbols == []
 
 
 def test_parse_ccp_warnings_multiple_types(tmp_path, caplog):
     """All three warning types in the same file are each handled."""
     fname = "net/core/sock.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -565,13 +575,13 @@ def test_parse_ccp_warnings_multiple_types(tmp_path, caplog):
 
     assert "Symbol tcp_v4_connect contains optimized clone: tcp_v4_connect.isra.0" in caplog.text
     assert "Unable to verify if lockdep_rtnl_is_held symbol is inlined or not. Please check manually." in caplog.text
-    assert cs.files[fname]["dup_symbols"] == ["nf_conntrack_in"]
+    assert cs.files[fname].dup_symbols == ["nf_conntrack_in"]
 
 
 def test_parse_ccp_warnings_respects_start_pos(tmp_path):
     """Lines written before start_pos are not parsed."""
     fname = "drivers/scsi/sd.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -581,13 +591,13 @@ def test_parse_ccp_warnings_respects_start_pos(tmp_path):
         f.write('conflicting definitions for symbol "sd_open" found in ELF\n')
         parse_ccp_warnings(f, start_pos, cs, fname)
 
-    assert cs.files[fname]["dup_symbols"] == ["sd_open"]
+    assert cs.files[fname].dup_symbols == ["sd_open"]
 
 
 def test_parse_ccp_warnings_multiple_dup_symbols(tmp_path):
     """Multiple conflicting-definition lines all append to dup_symbols."""
     fname = "mm/slub.c"
-    cs = FakeCS({fname: {}})
+    cs = FakeCS({fname: AffectedFile(fname)})
     log = tmp_path / "ccp.out.txt"
 
     with open(log, "w+") as f:
@@ -596,4 +606,4 @@ def test_parse_ccp_warnings_multiple_dup_symbols(tmp_path):
         f.write('conflicting definitions for symbol "kmem_cache_free" found in ELF\n')
         parse_ccp_warnings(f, start_pos, cs, fname)
 
-    assert cs.files[fname]["dup_symbols"] == ["kmem_cache_alloc", "kmem_cache_free"]
+    assert cs.files[fname].dup_symbols == ["kmem_cache_alloc", "kmem_cache_free"]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,24 +26,27 @@ def test_missing_conf_prefix(caplog):
     assert "Invalid config 'TUN': Missing CONFIG_ prefix" in caplog.text
 
 
+def _assert_tun_file(fdat):
+    assert fdat.module_name == "tun"
+    assert fdat.config_name == "CONFIG_TUN"
+    assert fdat.affected_symbols == {"tun_chr_ioctl", "tun_free_netdev"}
+
+
 def test_file_funcs_ok():
     # Check for multiple variants of file-funcs
     cs = Codestream(CS)
 
     setup_manual([cs], utils.ARCHS, "CONFIG_TUN", "tun",
                  [["drivers/net/tun.c", "tun_chr_ioctl", "tun_free_netdev"]], [], [])
-    assert cs.files["drivers/net/tun.c"] == \
-            {"module": "tun", "conf": "CONFIG_TUN", "symbols": ["tun_chr_ioctl", "tun_free_netdev"]}
+    _assert_tun_file(cs.files["drivers/net/tun.c"])
 
     setup_manual([cs], utils.ARCHS, "CONFIG_TUN", "tun", [],
                  [["tun", "drivers/net/tun1.c", "tun_chr_ioctl", "tun_free_netdev"]], [])
-    assert cs.files["drivers/net/tun1.c"] == \
-            {"module": "tun", "conf": "CONFIG_TUN", "symbols": ["tun_chr_ioctl", "tun_free_netdev"]}
+    _assert_tun_file(cs.files["drivers/net/tun1.c"])
 
     setup_manual([cs], utils.ARCHS, "CONFIG_TUN", "tun", [], [],
                  [["CONFIG_TUN", "tun", "drivers/net/tun2.c", "tun_chr_ioctl", "tun_free_netdev"]])
-    assert cs.files["drivers/net/tun2.c"] == \
-            {"module": "tun", "conf": "CONFIG_TUN", "symbols": ["tun_chr_ioctl", "tun_free_netdev"]}
+    _assert_tun_file(cs.files["drivers/net/tun2.c"])
 
 
 def test_non_existent_file():
@@ -140,9 +143,9 @@ def test_valite_conf_mod_file_funcs():
 
     sch = cs.files["net/sched/sch_qfq.c"]
     bts = cs.files["drivers/bluetooth/btsdio.c"]
-    assert sch["conf"] == bts["conf"]
-    assert sch["module"] == "sch_qfq"
-    assert bts["module"] == "btsdio"
+    assert sch.config_name == bts.config_name
+    assert sch.module_name == "sch_qfq"
+    assert bts.module_name == "btsdio"
 
     setup_manual([cs], utils.ARCHS, "CONFIG_NET_SCH_QFQ", "sch_qfq",
                  [["net/sched/sch_qfq.c", "qfq_change_class"]], [],
@@ -151,10 +154,10 @@ def test_valite_conf_mod_file_funcs():
 
     sch = cs.files["net/sched/sch_qfq.c"]
     bts = cs.files["drivers/bluetooth/btsdio.c"]
-    assert sch["conf"] == "CONFIG_NET_SCH_QFQ"
-    assert sch["module"] == "sch_qfq"
-    assert bts["conf"] == "CONFIG_BT_HCIBTSDIO"
-    assert bts["module"] == "btsdio"
+    assert sch.config_name == "CONFIG_NET_SCH_QFQ"
+    assert sch.module_name == "sch_qfq"
+    assert bts.config_name == "CONFIG_BT_HCIBTSDIO"
+    assert bts.module_name == "btsdio"
 
 
 def test_symbol_with_noinstr(caplog):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -255,3 +255,26 @@ def test_find_obj_path():
     assert "usr/lib/modules/6.12.0-160000.5-default/kernel/net/bluetooth/bluetooth.ko.zst" == str(
         cs.find_obj_path("x86_64", "net/bluetooth/bluetooth")
     )
+
+
+def test_conf_mod_file_funcs():
+    """
+    Make sure that we support the other variants of file-funcs arguments
+    """
+    lp = "bsc_" + inspect.currentframe().f_code.co_name
+
+    setup_args = {
+        "cve": None,
+        "lp_name": lp,
+        "archs": utils.ARCHS,
+        "module": None,
+        "file_funcs": [],
+        "mod_file_funcs": [],
+        "conf_mod_file_funcs": [["CONFIG_CIFS", "cifs", "fs/smb/client/cifs_spnego.c", "cifs_spnego_key_destroy"],
+                                ["CONFIG_KEYS", "vmlinux", "security/keys/key.c", "key_alloc"]],
+        "full_checks": False,
+        "lp_filter": CS,
+        "no_check": True,
+        "conf": None
+    }
+    setup(**setup_args)

--- a/tests/test_templ.py
+++ b/tests/test_templ.py
@@ -9,10 +9,21 @@ import pytest
 
 import klpbuild.klplib.templ as templ_module
 from klpbuild.klplib import utils
+from klpbuild.klplib.affected_file import AffectedFile
 from klpbuild.klplib.templ import get_multi_funcs
 from klpbuild.plugins.extract import extract
 from klpbuild.plugins.setup import run as setup
 from tests.utils import FakeCS, get_codestreams_file, get_file_content
+
+
+def _af(name, ext_symbols=None, klpp_symbols=None):
+    """Build an AffectedFile with extraction-phase fields set."""
+    f = AffectedFile(name)
+    if ext_symbols is not None:
+        f.ext_symbols = ext_symbols
+    if klpp_symbols is not None:
+        f.klpp_symbols = klpp_symbols
+    return f
 
 _generate_klpp_header = templ_module.__dict__["__generate_klpp_header"]
 
@@ -417,13 +428,14 @@ def test_templ_kbuild_has_contents():
 
 def test_get_multi_funcs_ibt_returns_empty():
     """IBT codestreams don't need the multi-entry wiring file."""
-    assert get_multi_funcs(FakeCS({}, ibt=True), "bsc123") == ("", "")
+    assert get_multi_funcs(FakeCS(ibt=True), "bsc123") == ("", "")
 
 
 def test_get_multi_funcs_no_ext_symbols():
     """Files without ext_symbols are skipped; only the initial ret line remains."""
     inits, cleanups = get_multi_funcs(
-        FakeCS({"fs/proc/cmdline.c": {"ext_symbols": {}}}), "bsc123"
+        FakeCS({"fs/proc/cmdline.c": _af("fs/proc/cmdline.c", ext_symbols={})}),
+        "bsc123",
     )
 
     assert "\tint ret;\n" in inits
@@ -433,7 +445,8 @@ def test_get_multi_funcs_no_ext_symbols():
 def test_get_multi_funcs_vmlinux_file():
     """A file whose symbols live in vmlinux: _init added, no _cleanup."""
     inits, cleanups = get_multi_funcs(
-        FakeCS({"fs/proc/cmdline.c": {"ext_symbols": {"seq_printf": "vmlinux"}}}),
+        FakeCS({"fs/proc/cmdline.c": _af("fs/proc/cmdline.c",
+                                         ext_symbols={"seq_printf": "vmlinux"})}),
         "bsc123",
     )
 
@@ -445,11 +458,8 @@ def test_get_multi_funcs_module_file():
     """A file whose symbols come from a module: both _init and _cleanup added."""
     inits, cleanups = get_multi_funcs(
         FakeCS(
-            {
-                "drivers/nvme/host/tcp.c": {
-                    "ext_symbols": {"nvme_tcp_try_send": "nvme_tcp"}
-                }
-            },
+            {"drivers/nvme/host/tcp.c": _af("drivers/nvme/host/tcp.c",
+                                            ext_symbols={"nvme_tcp_try_send": "nvme_tcp"})},
             mods={"drivers/nvme/host/tcp.c": "nvme_tcp"},
         ),
         "bsc123",
@@ -464,10 +474,10 @@ def test_get_multi_funcs_multiple_files():
     inits, cleanups = get_multi_funcs(
         FakeCS(
             {
-                "fs/proc/cmdline.c": {"ext_symbols": {"seq_printf": "vmlinux"}},
-                "drivers/nvme/host/tcp.c": {
-                    "ext_symbols": {"nvme_tcp_try_send": "nvme_tcp"}
-                },
+                "fs/proc/cmdline.c": _af("fs/proc/cmdline.c",
+                                         ext_symbols={"seq_printf": "vmlinux"}),
+                "drivers/nvme/host/tcp.c": _af("drivers/nvme/host/tcp.c",
+                                               ext_symbols={"nvme_tcp_try_send": "nvme_tcp"}),
             },
             mods={"drivers/nvme/host/tcp.c": "nvme_tcp"},
         ),
@@ -485,8 +495,9 @@ def test_get_multi_funcs_skips_file_without_ext_symbols():
     inits, cleanups = get_multi_funcs(
         FakeCS(
             {
-                "fs/proc/cmdline.c": {"ext_symbols": {"seq_printf": "vmlinux"}},
-                "net/ipv6/rpl.c": {"ext_symbols": {}},
+                "fs/proc/cmdline.c": _af("fs/proc/cmdline.c",
+                                         ext_symbols={"seq_printf": "vmlinux"}),
+                "net/ipv6/rpl.c": _af("net/ipv6/rpl.c", ext_symbols={}),
             }
         ),
         "bsc123",
@@ -500,7 +511,8 @@ def test_get_multi_funcs_skips_file_without_ext_symbols():
 def test_get_multi_funcs_hyphen_in_lp_name():
     """Hyphens in lp_name are converted to underscores in the generated symbol names."""
     inits, _ = get_multi_funcs(
-        FakeCS({"fs/proc/cmdline.c": {"ext_symbols": {"seq_printf": "vmlinux"}}}),
+        FakeCS({"fs/proc/cmdline.c": _af("fs/proc/cmdline.c",
+                                         ext_symbols={"seq_printf": "vmlinux"})}),
         "bsc-1234",
     )
 
@@ -513,22 +525,16 @@ def test_get_multi_funcs_hyphen_in_lp_name():
 
 def test_generate_klpp_header_empty_files():
     """No source files → empty string."""
-    assert _generate_klpp_header(FakeCS({})) == ""
+    assert _generate_klpp_header(FakeCS()) == ""
 
 
 def test_generate_klpp_header_no_structs():
     """Protos without struct parameters → sorted function declarations only."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "baz": "void klpp_baz(int x);",
-                        "bar": "int klpp_bar(void);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "baz": "void klpp_baz(int x);",
+            "bar": "int klpp_bar(void);",
+        })})
     )
 
     assert "int klpp_bar(void);" in result
@@ -541,15 +547,9 @@ def test_generate_klpp_header_no_structs():
 def test_generate_klpp_header_with_structs():
     """Proto with a struct parameter → forward declaration prepended."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "bar": "int klpp_bar(struct sk_buff *skb);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "bar": "int klpp_bar(struct sk_buff *skb);",
+        })})
     )
 
     assert "struct sk_buff;" in result
@@ -560,16 +560,12 @@ def test_generate_klpp_header_with_structs():
 def test_generate_klpp_header_dedup_structs():
     """The same struct appearing in multiple protos is declared only once."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {"foo": "int klpp_foo(struct sk_buff *skb);"}
-                },
-                "bar.c": {
-                    "klpp_symbols": {"bar": "int klpp_bar(struct sk_buff *pkt);"}
-                },
-            }
-        )
+        FakeCS({
+            "foo.c": _af("foo.c", klpp_symbols={
+                "foo": "int klpp_foo(struct sk_buff *skb);"}),
+            "bar.c": _af("bar.c", klpp_symbols={
+                "bar": "int klpp_bar(struct sk_buff *pkt);"}),
+        })
     )
 
     assert result.count("struct sk_buff;") == 1
@@ -578,15 +574,9 @@ def test_generate_klpp_header_dedup_structs():
 def test_generate_klpp_header_multiple_structs_sorted():
     """Multiple distinct structs are forward-declared in alphabetical order."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "foo": "int klpp_foo(struct zebra *z, struct alpha *a);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "foo": "int klpp_foo(struct zebra *z, struct alpha *a);",
+        })})
     )
 
     assert "struct alpha;" in result
@@ -597,12 +587,10 @@ def test_generate_klpp_header_multiple_structs_sorted():
 def test_generate_klpp_header_empty_klpp_symbols_in_file():
     """A file with an empty klpp_symbols dict contributes nothing."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {"klpp_symbols": {}},
-                "bar.c": {"klpp_symbols": {"baz": "void klpp_baz(void);"}},
-            }
-        )
+        FakeCS({
+            "foo.c": _af("foo.c", klpp_symbols={}),
+            "bar.c": _af("bar.c", klpp_symbols={"baz": "void klpp_baz(void);"}),
+        })
     )
 
     assert result == "void klpp_baz(void);"
@@ -611,15 +599,9 @@ def test_generate_klpp_header_empty_klpp_symbols_in_file():
 def test_generate_klpp_header_struct_in_return_type():
     """A struct in the return type also triggers a forward declaration."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "bar": "struct sk_buff *klpp_bar(void);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "bar": "struct sk_buff *klpp_bar(void);",
+        })})
     )
 
     assert "struct sk_buff;" in result
@@ -629,12 +611,10 @@ def test_generate_klpp_header_struct_in_return_type():
 def test_generate_klpp_header_funcs_sorted_across_files():
     """Prototypes from multiple files are sorted together, not per-file."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {"klpp_symbols": {"zoo": "void klpp_zoo(void);"}},
-                "bar.c": {"klpp_symbols": {"alpha": "int klpp_alpha(void);"}},
-            }
-        )
+        FakeCS({
+            "foo.c": _af("foo.c", klpp_symbols={"zoo": "void klpp_zoo(void);"}),
+            "bar.c": _af("bar.c", klpp_symbols={"alpha": "int klpp_alpha(void);"}),
+        })
     )
 
     assert result.index("klpp_alpha") < result.index("klpp_zoo")
@@ -643,15 +623,9 @@ def test_generate_klpp_header_funcs_sorted_across_files():
 def test_generate_klpp_header_with_enum():
     """Proto with an enum parameter → forward declaration prepended."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "bar": "void klpp_bar(enum color c);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "bar": "void klpp_bar(enum color c);",
+        })})
     )
 
     assert "enum color;" in result
@@ -662,15 +636,9 @@ def test_generate_klpp_header_with_enum():
 def test_generate_klpp_header_enum_in_return_type():
     """An enum in the return type also triggers a forward declaration."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "bar": "enum color klpp_bar(void);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "bar": "enum color klpp_bar(void);",
+        })})
     )
 
     assert "enum color;" in result
@@ -680,16 +648,12 @@ def test_generate_klpp_header_enum_in_return_type():
 def test_generate_klpp_header_dedup_enums():
     """The same enum appearing in multiple protos is declared only once."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {"foo": "void klpp_foo(enum color c);"}
-                },
-                "bar.c": {
-                    "klpp_symbols": {"bar": "void klpp_bar(enum color d);"}
-                },
-            }
-        )
+        FakeCS({
+            "foo.c": _af("foo.c", klpp_symbols={
+                "foo": "void klpp_foo(enum color c);"}),
+            "bar.c": _af("bar.c", klpp_symbols={
+                "bar": "void klpp_bar(enum color d);"}),
+        })
     )
 
     assert result.count("enum color;") == 1
@@ -698,15 +662,9 @@ def test_generate_klpp_header_dedup_enums():
 def test_generate_klpp_header_mixed_struct_and_enum():
     """Structs appear before enums, each group sorted, separated by blank line."""
     result = _generate_klpp_header(
-        FakeCS(
-            {
-                "foo.c": {
-                    "klpp_symbols": {
-                        "foo": "int klpp_foo(struct zebra *z, enum alpha a);",
-                    }
-                }
-            }
-        )
+        FakeCS({"foo.c": _af("foo.c", klpp_symbols={
+            "foo": "int klpp_foo(struct zebra *z, enum alpha a);",
+        })})
     )
 
     assert "struct zebra;" in result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,9 +187,14 @@ def test_filter_codestreams_by_arch():
     assert not utils.filter_codestreams_by_arch([], [non_rt_cs])
 
 
+def _archs_as_module(archs):
+    """Build a per-arch CONFIG dict in the AffectedConfig shape (state irrelevant here)."""
+    return {arch: "m" for arch in archs}
+
+
 def test_affected_archs():
-    cs1 = Codestream("15.5u10", configs={"CONFIG_A": ["x86_64", "s390x"]})
-    cs2 = Codestream("15.5u11", configs={"CONFIG_B": ["ppc64le"]})
+    cs1 = Codestream("15.5u10", configs={"CONFIG_A": _archs_as_module(["x86_64", "s390x"])})
+    cs2 = Codestream("15.5u11", configs={"CONFIG_B": _archs_as_module(["ppc64le"])})
 
     assert utils.affected_archs([cs1]) == ["s390x", "x86_64"]
     assert utils.affected_archs([cs2]) == ["ppc64le"]
@@ -201,7 +206,7 @@ def test_affected_archs():
 
 def test_preferred_arch():
     def make_cs(archs):
-        return Codestream("15.5u10", configs={"CONFIG_A": archs})
+        return Codestream("15.5u10", configs={"CONFIG_A": _archs_as_module(archs)})
 
     # x86_64 is top priority
     assert utils.preferred_arch([make_cs(["x86_64", "s390x", "ppc64le"])]) == "x86_64"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,22 +6,24 @@
 from pathlib import Path
 import json
 
+from klpbuild.klplib.affected_file import AffectedConfig, AffectedFile, AffectedModule
 from klpbuild.klplib.utils import get_workdir
 
 
 class FakeCS:
-    def __init__(self, files, cs_name="15.4u0", ibt=False, mods=None,
+    def __init__(self, files=None, cs_name="15.4u0", ibt=False, mods=None,
                  configs=None, modules=None, patches=None, branch="main",
                  supported=None):
-        self.files = files
+        self.files: dict[str, AffectedFile] = files or {}
         self._cs_name = cs_name
         self._ibt = ibt
         self._mods = mods or {}
-        self.configs = configs or {}
-        self.modules = modules if modules is not None else {}
+        self.configs: dict[str, AffectedConfig] = configs or {}
+        self.modules: dict[str, AffectedModule] = modules or {}
         self._patches = patches or []
         self._branch = branch
         self._supported = supported or {}
+        self._mod_cache: dict[str, AffectedModule] = {}
 
     def full_cs_name(self):
         return self._cs_name
@@ -32,8 +34,17 @@ class FakeCS:
     def lp_out_file(self, lp, f):
         return f"{lp}_{f.replace('/', '_').replace('-', '_')}"
 
-    def get_file_mod(self, f):
-        return self._mods.get(f, "vmlinux")
+    def get_file_mod(self, f, arch=None):
+        # Mirrors Codestream.get_file_mod: returns an AffectedModule, with the
+        # same instance returned across calls so cache_obj_path mutations stay
+        # visible (matching Codestream.modules.setdefault semantics).
+        name = self._mods.get(f, AffectedModule.VMLINUX)
+        if name not in self._mod_cache:
+            self._mod_cache[name] = (
+                AffectedModule.vmlinux() if name == AffectedModule.VMLINUX
+                else AffectedModule(name)
+            )
+        return self._mod_cache[name]
 
     def get_required_patches(self):
         return self._patches
@@ -44,7 +55,7 @@ class FakeCS:
     def set_configs(self, config_names):
         for c in config_names:
             if c not in self.configs:
-                self.configs[c] = {}
+                self.configs[c] = AffectedConfig(c)
 
     def is_module_supported(self, mod):
         return self._supported.get(mod, (True, False))


### PR DESCRIPTION
This work was based on top of #242 . This is needed when we need to create a livepatch targetting two different subsystems  with different modules and configs, usually meaning that we can't really use the upstream fix and we need a manual approach.

Please review!