### PR TITLE
plugins: extract: Remove __sched attribute

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -342,7 +342,7 @@ def get_klpp_symbols(out_dir, lp_out):
             klpp_proto = re.sub(r'\s+', ' ', m.group(2)).strip() + ';'
             # Remove the attributes left by klp-ccp, since they don't mean much
             # for kernel modules
-            klpp_proto = re.sub(r' __(init|exit)', ' ', klpp_proto)
+            klpp_proto = re.sub(r' __(init|exit|sched)', ' ', klpp_proto)
             klpp_syms.update({sym: klpp_proto})
 
             # Remove the 'static' keyword in the prototypes, if any

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -132,19 +132,21 @@ def test_get_klpp_symbols_function_pointer_param(tmp_path):
     assert result == {"foo": "int klpp_foo(int (*cb)(void));"}
 
 
-def test_get_klpp_symbols_strips_init_exit(tmp_path):
+def test_get_klpp_symbols_strips_init_exit_sched(tmp_path):
     r"""__init and __exit are part of ([\w\*]\s*)* and stripped from the proto."""
     lp_out = tmp_path / "lp.c"
     lp_out.write_text(
         "static int __init klpp_foo(void)\n{\n    return 0;\n}\n"
         "static void __exit klpp_bar(void)\n{\n}\n"
+        "static void __sched klpp_baz(void)\n{\n}\n"
     )
-    (tmp_path / "patched_funcs").write_text("foo\nbar\n")
+    (tmp_path / "patched_funcs").write_text("foo\nbar\nbaz\n")
 
     result = get_klpp_symbols(tmp_path, lp_out)
 
     assert "__init" not in result["foo"]
     assert "__exit" not in result["bar"]
+    assert "__sched" not in result["baz"]
 
 
 def test_get_klpp_symbols_multiple_symbols(tmp_path):


### PR DESCRIPTION
The __sched is translated to __section(".sched.text"), which isn't handled by the module linker script. The functions inside this section are not shown in the stack traces, but it's only meaningful for functions builtin in the kernel, and not for modules, such as livepatches.