### PR TITLE
Check parent bug

### DIFF
--- a/klpbuild/klplib/ksrc.py
+++ b/klpbuild/klplib/ksrc.py
@@ -190,18 +190,22 @@ def store_patch(pfile, patch, savedir, savedir_idx, bc):
         f.write(pfile)
 
 
-def get_branch_patches(cve, mbranch):
+def get_branch_patches(cve, mbranch, parent=None):
     kern_src = get_user_path('kernel_src_dir')
+
+    search_string = f"CVE-{cve}"
+    if parent:
+        search_string += f"|bsc#{parent}"
 
     try:
         patch_files = subprocess.check_output(
-            ["/usr/bin/git", "-C", kern_src, "grep", "-l", f"CVE-{cve}",
+            ["/usr/bin/git", "-C", kern_src, "grep", "-E", "-l", search_string,
              f"remotes/origin/{mbranch}", "--", "patches.suse/"],
             stderr=subprocess.STDOUT,
         ).decode(sys.stdout.encoding)
     except subprocess.CalledProcessError:
         # If we don't find any commits for RT branchs, try with the non-RT variant.
-        return [] if "RT" not in mbranch else get_branch_patches(cve, mbranch.replace("-RT", ""))
+        return [] if "RT" not in mbranch else get_branch_patches(cve, mbranch.replace("-RT", ""), parent)
 
     # Prepare command to extract correct ordering of patches
     cmd = ["/usr/bin/git", "-C", kern_src, "grep", "-o", "-h"]
@@ -221,7 +225,7 @@ def get_branch_patches(cve, mbranch):
 
 
 @__check_kernel_source_tags_are_fetched
-def get_patches(cve, savedir=None, extra_patches=None):
+def get_patches(cve, savedir=None, extra_patches=None, parent=None):
     if extra_patches is None:
         extra_patches = []
 
@@ -261,7 +265,7 @@ def get_patches(cve, savedir=None, extra_patches=None):
             else:
                 logging.debug("\textra patch %s not found in %s", extra_patch, mbranch)
 
-        for patch in get_branch_patches(cve, mbranch):
+        for patch in get_branch_patches(cve, mbranch, parent):
             if patch.strip().startswith("#"):
                 continue
 

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -137,7 +137,7 @@ def scan_job(bug, cve):
     return result
 
 
-def scan(cve, conf, lp_filter, download, archs=None, savedir=None, extra_patches=None):
+def scan(cve, conf, lp_filter, download, archs=None, savedir=None, extra_patches=None, parent=None):
     if archs is None:
         archs = utils.ARCHS
     if extra_patches is None:
@@ -145,7 +145,7 @@ def scan(cve, conf, lp_filter, download, archs=None, savedir=None, extra_patches
 
     assert cve and utils.is_cve_valid(cve)
 
-    upstream, patches = get_patches(cve, savedir, extra_patches)
+    upstream, patches = get_patches(cve, savedir, extra_patches, parent)
 
     all_codestreams = get_supported_codestreams()
     filtered_codesteams = utils.filter_codestreams(lp_filter, all_codestreams, verbose=True)

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -178,8 +178,13 @@ def setup_codestreams(lp_name, data):
         all_codestreams = get_supported_codestreams()
         codestreams = utils.filter_codestreams(data["lp_filter"], all_codestreams)
     else:
+        bug = bugzilla.get_bug(lp_name)
+        if len(bug.depends_on) == 1:
+            data["parent"] = bug.depends_on[0]
+            logging.info("Using parent bsc number to help tracking backports: %s", data["parent"])
+
         if not (cve := data["cve"]):
-            cve = bugzilla.get_bug_cve(bugzilla.get_bug(lp_name))
+            cve = bugzilla.get_bug_cve(bug)
             assert cve, f"Could not retrieve CVE from bugzilla for {lp_name}"
             logging.info("CVE retrieved from bugzilla: %s", cve)
             data["cve"] = cve
@@ -188,7 +193,8 @@ def setup_codestreams(lp_name, data):
                                                     data["lp_filter"], True,
                                                     data["archs"],
                                                     utils.get_workdir(lp_name),
-                                                    data.get("extra_patches", []))
+                                                    data.get("extra_patches", []),
+                                                    data["parent"])
 
     # Add new codestreams names to the already existing list, skipping
     # duplicates


### PR DESCRIPTION
There are times that a bug is under embargo, or don't have a CVE assigned, but these patches have references to the bug number that is tracking the vulnerability. Use the parent bug number to help getting these patches.

Created on top of Vincenzo's PR.