### PR TITLE
plugins/commit: reset kgraft HEAD back to 'main'

### DIFF
--- a/klpbuild/klplib/kgraft.py
+++ b/klpbuild/klplib/kgraft.py
@@ -38,6 +38,17 @@ def get_kgraft():
     return __KGR_PATH
 
 
+def reset_kgraft():
+    '''
+        Checkout to the worktree's main branch
+    '''
+    subprocess.check_output(
+            ["git", "checkout", "-f", TREE_NAME],
+            cwd=get_kgraft(),
+            stderr=subprocess.STDOUT,
+            )
+
+
 def fetch_branch(branch, remote="origin"):
     subprocess.check_output(
         ["git", "fetch", remote, branch],
@@ -69,11 +80,7 @@ def delete_lp_branches(branches):
     if not branches:
         return
 
-    subprocess.check_output(
-            ["git", "checkout", "-f", TREE_NAME],
-            cwd=get_kgraft(),
-            stderr=subprocess.STDOUT,
-            )
+    reset_kgraft()
 
     for bname in branches:
         err = subprocess.run(["git", "branch", "-D", bname], cwd=get_kgraft(),

--- a/klpbuild/plugins/commit.py
+++ b/klpbuild/plugins/commit.py
@@ -15,7 +15,8 @@ from klpbuild.klplib.kgraft import (find_lp_branches,
                                     create_lp_branch,
                                     commit_lp_changes,
                                     get_kgraft,
-                                    init_kgraft)
+                                    init_kgraft,
+                                    reset_kgraft)
 
 PLUGIN_CMD = "commit"
 
@@ -53,6 +54,8 @@ def commit(lp_name, codestreams, force):
         shutil.copytree(code_path, f"{get_kgraft()}/{lp_name}", dirs_exist_ok=True)
         commit_lp_changes(lp_name)
         logging.info("Livepatch '%s' commited", branch)
+
+    reset_kgraft()
 
 
 def run(lp_name, lp_filter, force):


### PR DESCRIPTION
Once the livepatch has been commited, change the HEAD back to worktree's own 'main' branch. Otherwise it will block accessing the current lp branch by other worktrees and main repository.