### PR TITLE
utils: Fix codestream filtering

### DIFF
--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -316,7 +316,7 @@ def filter_codestreams(lp_filter, cs_list, verbose=False):
     filtered = []
     for cs in cs_list:
         name = cs.full_cs_name()
-        if re.match(lp_filter, name):
+        if re.fullmatch(lp_filter, name):
             result.append(cs)
         else:
             filtered.append(name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,6 +144,8 @@ def test_filter_codestreams():
         Codestream("15.3u10"),
         Codestream("15.5u6"),
         Codestream("6.0u0"),
+        Codestream("16.0u1"),
+        Codestream("16.0u10"),
     ]
 
     # No filter returns all
@@ -163,6 +165,10 @@ def test_filter_codestreams():
 
     # No match returns empty list
     assert not utils.filter_codestreams("99\\..*", cs_list)
+
+    # A filter naming a single update must not also match longer updates that
+    # start with the same digits
+    assert utils.filter_codestreams("16.0u1", cs_list) == [Codestream("16.0u1")]
 
 
 def test_filter_codestreams_by_arch():


### PR DESCRIPTION
filter_codestreams() incorrectly matches codestreams which share the same string start as the filter regex. For example:
	`--filter "16.0rtu1"`
returns:
	`"16.0rtu1, 16.0rtu10, 16.0rtu11, 16.0rtu12, 16.0rtu13,
	16.0rtu13, 16.0rtu15"`

Doing a full match instead fixes the issue.