### PR TITLE
extract: Support 'STATIC' klpe declarations

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -265,7 +265,7 @@ def fix_ext_symbols(cs, fdata: AffectedFile, lp_out):
     for sym_list in fdata.ext_symbols.values():
         for s in sym_list:
             # Keep only static declarations
-            lp_out = re.sub(rf"^(?!static|\s|#)\w[^;:()=]+\(\*klpe_{s}\)[^;:=]*;",
+            lp_out = re.sub(rf"^(?!(?:static|STATIC)|\s|#)\w[^;:()=]+\(\*klpe_{s}\)[^;:=]*;",
                             '', lp_out, flags=re.MULTILINE)
 
 


### PR DESCRIPTION
klp-ccp preserves the 'STATIC' literal token rather than expanding it, so the old regex was incorrectly stripping those declarations as "non-static."