### PR TITLE
plugins/extract: Remove leftover typeofs() on cleanup

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -802,6 +802,7 @@ def lp_out_cleanup(cs, fdata: AffectedFile, lp_out, sdir):
     - Remove the attributes left by klp-ccp, since they don't mean much for
       kernel modules.
     - Fix externalized symbols declaration.
+    - Remove typeof(...) declarations left by klp-ccp.
     - Remove big chunks of empty lines.
     """
     macros = '|'.join(UNSUPPORTED_MACROS)
@@ -814,6 +815,7 @@ def lp_out_cleanup(cs, fdata: AffectedFile, lp_out, sdir):
         file_buf = re.sub(fr"#include \"{str(sdir)}.*\.h\"", '', file_buf)
         file_buf = re.sub(fr"#define\s({macros}).*", '', file_buf)
         file_buf = re.sub(r" __(init|exit)", ' ', file_buf)
+        file_buf = re.sub(r'^typeof\(.*?;\n?', '', file_buf, flags=re.MULTILINE | re.DOTALL)
         file_buf = fix_ext_symbols(cs, fdata, file_buf)
         file_buf = re.sub(r'\n{3,}', r'\n', file_buf)
         f.write(file_buf)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -483,6 +483,31 @@ def test_lp_out_cleanup_removes_init_exit_attributes(tmp_path):
     assert "__init" not in lp_out.read_text()
 
 
+def test_lp_out_cleanup_removes_typeof_variable_declaration(tmp_path):
+    """A 'typeof(TYPE) VAR;' declaration, where a variable name follows the
+    closing paren before the semicolon, is removed in full."""
+    lp_out = _make_lp_out(
+        tmp_path,
+        "typeof(klpp_ulpi_register_interface) klpp_ulpi_register_interface;\n"
+        "static int foo(void)\n{\n}\n",
+    )
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
+    content = lp_out.read_text()
+    assert "typeof(" not in content
+    assert "klpp_ulpi_register_interface" not in content
+    assert "static int foo(void)" in content
+
+
+def test_lp_out_cleanup_keeps_indented_typeof(tmp_path):
+    """Only lines starting with 'typeof(' at column 0 are removed; indented
+    occurrences (e.g. inside a function body) are left untouched."""
+    lp_out = _make_lp_out(
+        tmp_path, "static int foo(void)\n{\n\ttypeof(bar) x;\n}\n"
+    )
+    lp_out_cleanup(Codestream("15.4u0"), _make_fdata(), lp_out, tmp_path)
+    assert "typeof(bar) x;" in lp_out.read_text()
+
+
 def test_lp_out_cleanup_collapses_multiple_empty_lines(tmp_path):
     """Three or more consecutive blank lines are collapsed to one."""
     lp_out = _make_lp_out(tmp_path, "line1\n\n\n\nline2\n")


### PR DESCRIPTION
`klp-cc` has a tendency to include typeofs declarations for klpe and klpp functions. Such declarations always cause conflicts during livepatch compilation.
It's safer to just remove them altogether.

Note that `extern typeofs` are not targeted by this change.