### PR TITLE
plugins:extract: Remove klpp symbols declarations

### DIFF
--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -315,6 +315,26 @@ def get_ext_symbols(out_dir):
     return symbols
 
 
+def fix_klpp_symbols(fdata: AffectedFile, lp_out):
+    '''
+        - Removes any klpp function declaration in the .c files to
+          avoid signature conflicts with the declarations in the header
+          file during compilation.
+          Inlined klpp functions are not affected.
+        - Remove 'static' keyword from klpp function definition.
+    '''
+
+    for sym, proto in fdata.klpp_symbols.items():
+        rfmt = fr"[\w\*\s]+?\bklpp_{sym}\s*\([^()]*(?:\([^()]*\)[^()]*)*\)\s*;\n?"
+        lp_out = re.sub(rfmt, '', lp_out, flags=re.S)
+
+        # Remove the 'static' keyword in the prototypes, if any
+        proto = proto.rstrip(';')
+        lp_out = re.sub(fr'(static|STATIC)\s+{re.escape(proto)}', proto, lp_out)
+
+    return lp_out
+
+
 def get_klpp_symbols(out_dir, lp_out, mod_name):
     fpath = Path(out_dir, "patched_funcs")
     if not fpath.exists():
@@ -346,12 +366,6 @@ def get_klpp_symbols(out_dir, lp_out, mod_name):
             # for kernel modules
             klpp_proto = re.sub(r' __(init|exit|sched)', ' ', klpp_proto)
             klpp_syms.update({sym: klpp_proto})
-
-            # Remove the 'static' keyword in the prototypes, if any
-            lp_code = regex.sub(r'\2', lp_code)
-
-    with open(lp_out, "w") as f:
-        f.write(lp_code)
 
     return klpp_syms
 
@@ -805,6 +819,7 @@ def lp_out_cleanup(cs, fdata: AffectedFile, lp_out, sdir):
     - Remove the attributes left by klp-ccp, since they don't mean much for
       kernel modules.
     - Fix externalized symbols declaration.
+    - Fix klpp symbols declaration.
     - Remove typeof(...) declarations left by klp-ccp.
     - Remove big chunks of empty lines.
     """
@@ -820,6 +835,7 @@ def lp_out_cleanup(cs, fdata: AffectedFile, lp_out, sdir):
         file_buf = re.sub(r" __(init|exit)", ' ', file_buf)
         file_buf = re.sub(r'^typeof\(.*?;\n?', '', file_buf, flags=re.MULTILINE | re.DOTALL)
         file_buf = fix_ext_symbols(cs, fdata, file_buf)
+        file_buf = fix_klpp_symbols(fdata, file_buf)
         file_buf = re.sub(r'\n{3,}', r'\n', file_buf)
         f.write(file_buf)
         f.truncate()

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -17,6 +17,7 @@ from klpbuild.klplib.codestreams_data import load_codestreams
 from klpbuild.plugins.extract import (
     extract,
     fix_ext_symbols,
+    fix_klpp_symbols,
     get_ext_symbols,
     get_klpp_symbols,
     lp_out_cleanup,
@@ -26,10 +27,11 @@ from klpbuild.plugins.setup import run as setup
 from tests.utils import FakeCS
 
 
-def _make_fdata(ext_symbols=None):
-    """Create an AffectedFile with ext_symbols set for testing."""
+def _make_fdata(ext_symbols=None, klpp_symbols=None):
+    """Create an AffectedFile with ext_symbols/klpp_symbols set for testing."""
     f = AffectedFile("test.c")
     f.ext_symbols = ext_symbols or {}
+    f.klpp_symbols = klpp_symbols or {}
     return f
 
 
@@ -63,7 +65,20 @@ def test_get_klpp_symbols_simple_return_type(tmp_path):
     result = get_klpp_symbols(tmp_path, lp_out)
 
     assert result == {"foo": "int klpp_foo(int a, int b);"}
-    assert "static" not in lp_out.read_text()
+
+
+def test_get_klpp_symbols_does_not_modify_file(tmp_path):
+    """get_klpp_symbols only parses lp_out; it must not rewrite the file.
+    Stripping 'static' from the definition is fix_klpp_symbols's job,
+    applied later during lp_out_cleanup."""
+    content = "static int klpp_foo(int a, int b)\n{\n    return a + b;\n}\n"
+    lp_out = tmp_path / "lp.c"
+    lp_out.write_text(content)
+    (tmp_path / "patched_funcs").write_text("foo\n")
+
+    get_klpp_symbols(tmp_path, lp_out)
+
+    assert lp_out.read_text() == content
 
 
 def test_get_klpp_symbols_pointer_return_type(tmp_path):
@@ -342,6 +357,50 @@ def test_fix_ext_symbols_percpu_struct_pointer_type():
     result = fix_ext_symbols(cs, fdata, lp_out)
     assert "static struct foo * __percpu (*klpe_bar);" in result
     assert "__attribute__" not in result
+
+
+# ── fix_klpp_symbols ───────────────────────────────────────────────────────────
+
+def test_fix_klpp_symbols_strips_static_from_definition():
+    """The 'static' keyword is removed from the klpp function definition,
+    matching the stored (static-free) prototype."""
+    fdata = _make_fdata(klpp_symbols={"foo": "int klpp_foo(int a, int b);"})
+    lp_out = "static int klpp_foo(int a, int b)\n{\n    return a + b;\n}\n"
+    result = fix_klpp_symbols(fdata, lp_out)
+    assert "static" not in result
+    assert "int klpp_foo(int a, int b)\n{\n    return a + b;\n}\n" in result
+
+
+def test_fix_klpp_symbols_removes_duplicate_declaration():
+    """A standalone klpp function declaration (no body) is removed entirely,
+    since it duplicates the one already emitted in the header. The surviving
+    definition also has 'static' stripped."""
+    fdata = _make_fdata(klpp_symbols={"foo": "int klpp_foo(void);"})
+    lp_out = "int klpp_foo(void);\nstatic int klpp_foo(void)\n{\n    return 0;\n}\n"
+    result = fix_klpp_symbols(fdata, lp_out)
+    assert result == "int klpp_foo(void)\n{\n    return 0;\n}\n"
+
+
+def test_fix_klpp_symbols_no_static_definition_unchanged():
+    """When the definition never had 'static', the buffer is left as-is."""
+    fdata = _make_fdata(klpp_symbols={"foo": "int klpp_foo(void);"})
+    lp_out = "int klpp_foo(void)\n{\n    return 0;\n}\n"
+    result = fix_klpp_symbols(fdata, lp_out)
+    assert result == lp_out
+
+
+def test_fix_klpp_symbols_multiple_symbols_all_processed():
+    """Every symbol in fdata.klpp_symbols has its 'static' stripped."""
+    fdata = _make_fdata(klpp_symbols={
+        "alpha": "int klpp_alpha(void);",
+        "beta": "void klpp_beta(int x);",
+    })
+    lp_out = (
+        "static int klpp_alpha(void)\n{\n    return 0;\n}\n"
+        "static void klpp_beta(int x)\n{\n}\n"
+    )
+    result = fix_klpp_symbols(fdata, lp_out)
+    assert "static" not in result
 
 
 # ── get_ext_symbols ────────────────────────────────────────────────────────────

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -41,7 +41,7 @@ def test_get_klpp_symbols_missing_patched_funcs(tmp_path):
     lp_out.write_text("")
 
     with pytest.raises(RuntimeError, match="File not found"):
-        get_klpp_symbols(tmp_path, lp_out)
+        get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
 
 def test_get_klpp_symbols_no_static(tmp_path, caplog):
@@ -50,7 +50,7 @@ def test_get_klpp_symbols_no_static(tmp_path, caplog):
     lp_out.write_text("int klpp_foo(void)\n{\n    return 0;\n}\n")
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "int klpp_foo(void);"}
     assert "static" not in caplog.text
@@ -62,7 +62,7 @@ def test_get_klpp_symbols_simple_return_type(tmp_path):
     lp_out.write_text("static int klpp_foo(int a, int b)\n{\n    return a + b;\n}\n")
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "int klpp_foo(int a, int b);"}
 
@@ -76,7 +76,7 @@ def test_get_klpp_symbols_does_not_modify_file(tmp_path):
     lp_out.write_text(content)
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    get_klpp_symbols(tmp_path, lp_out)
+    get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert lp_out.read_text() == content
 
@@ -87,7 +87,7 @@ def test_get_klpp_symbols_pointer_return_type(tmp_path):
     lp_out.write_text("static char *klpp_foo(void)\n{\n    return NULL;\n}\n")
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "char *klpp_foo(void);"}
 
@@ -98,7 +98,7 @@ def test_get_klpp_symbols_multiword_return_type(tmp_path):
     lp_out.write_text("static unsigned long klpp_foo(int x)\n{\n    return 0;\n}\n")
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "unsigned long klpp_foo(int x);"}
 
@@ -111,7 +111,7 @@ def test_get_klpp_symbols_const_struct_pointer_return(tmp_path):
     )
     (tmp_path / "patched_funcs").write_text("bar\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"bar": "const struct foo *klpp_bar(struct foo *p);"}
 
@@ -122,7 +122,7 @@ def test_get_klpp_symbols_multiline_via_re_s(tmp_path):
     lp_out.write_text("static int\nklpp_baz(int a)\n{\n    return a;\n}\n")
     (tmp_path / "patched_funcs").write_text("baz\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert "baz" in result
     # Whitespace normalization must collapse the newline in the prototype
@@ -138,7 +138,7 @@ def test_get_klpp_symbols_params_with_pointer(tmp_path):
     )
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "int klpp_foo(int *p, struct bar *q);"}
 
@@ -149,7 +149,7 @@ def test_get_klpp_symbols_function_pointer_param(tmp_path):
     lp_out.write_text("static int klpp_foo(int (*cb)(void))\n{\n    return 0;\n}\n")
     (tmp_path / "patched_funcs").write_text("foo\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert result == {"foo": "int klpp_foo(int (*cb)(void));"}
 
@@ -164,7 +164,7 @@ def test_get_klpp_symbols_strips_init_exit_sched(tmp_path):
     )
     (tmp_path / "patched_funcs").write_text("foo\nbar\nbaz\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert "__init" not in result["foo"]
     assert "__exit" not in result["bar"]
@@ -180,7 +180,7 @@ def test_get_klpp_symbols_multiple_symbols(tmp_path):
     )
     (tmp_path / "patched_funcs").write_text("alpha\nbeta\ngamma\n")
 
-    result = get_klpp_symbols(tmp_path, lp_out)
+    result = get_klpp_symbols(tmp_path, lp_out, "test_mod")
 
     assert "alpha" in result
     assert "beta" in result


### PR DESCRIPTION
Remove all the klpp function declarations in the C files. Otherwise there might be signature conflicts during compilation, as klp-build already declares them in the header file.

A partial solution already existed in the past, but was removed in 2ccb6e0 ("extract: Skip klpp function declarations"). This commit adds a more robust fix, which effectively removes the any duped declaration. More importantly, it does the change only after the *.orig file has been created; which didn't happen in the past.