### PR TITLE
utils: Improve fast filtering

### DIFF
--- a/klpbuild/klplib/utils.py
+++ b/klpbuild/klplib/utils.py
@@ -283,26 +283,33 @@ def check_module_unsupported(arch, mod_path):
     return "no" == get_elf_modinfo_entry(elffile, "supported")
 
 
-def filter_fast(cs_list):
+def filter_fast(lp_name, cs_list):
     '''
-    Return the first codestream of each product. For example, given the list
-        15.5u10, 15.5u11, 12.5u10, 6.0u0
-    The return would be
-        15.5u10, 12.5u10, 6.0u0
+    Smart filtering that only returns a small subset of affected
+    codestreams based on the existing livepatch branches and groups.
+    The subset contains the first codestream of each product within each
+    livepatch branch.
+
+    For example, given the branches:
+        bsc123456_15.5u10-11_12.5u10_6.0-15
+        bsc123456_15.5u9
+    The return would be:
+        15.5u9, 15.5u10, 12.5u10, 6.0u0
+
+    The livepatch branches must already exist for the filtering to work.
 
     Returns:
-        List: Containing only one entry per product
+        List: Containing only a subset of affected codestreams
     '''
-    ret = []
-    cs_once = []
+    lp_filter = []
+    git_dir = get_user_path('kgr_patches_dir')
 
-    for c in cs_list:
-        base = c.base_cs_name()
-        if base not in cs_once:
-            ret.append(c)
-            cs_once.append(base)
+    for b in get_lp_branches(lp_name, git_dir):
+        b = b.replace(lp_name + "_", "")
+        r = re.sub(r"-[0-9]{1,2}", '', b).replace("_", '|')
+        lp_filter.append(r)
 
-    return ret
+    return filter_codestreams("|".join(lp_filter), cs_list)
 
 
 def filter_codestreams(lp_filter, cs_list, verbose=False):

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -138,10 +138,14 @@ def create_lp_package(osc, lp_name, i, total, cs):
 
 
 def run(lp_name, lp_filter, wait=False, fast=False):
+    cs_list = get_codestreams_list()
+
+    commit(lp_name, cs_list, force=False)
+
     if fast:
-        cs_list = filter_fast(get_codestreams_list())
+        cs_list = filter_fast(lp_name, cs_list)
     else:
-        cs_list = filter_codestreams(lp_filter, get_codestreams_list())
+        cs_list = filter_codestreams(lp_filter, cs_list)
 
     if not cs_list:
         logging.error("push: No codestreams found for %s", lp_name)
@@ -154,8 +158,6 @@ def run(lp_name, lp_filter, wait=False, fast=False):
 
     total = len(cs_list)
     i = 1
-
-    commit(lp_name, cs_list, force=False)
 
     # More threads makes OBS to return error 500
     for cs in cs_list:


### PR DESCRIPTION
The current fast implementation filters out too many codestreams. `--fast` should push the smallest possible subset of codestreams required to verify the correctness of the livepatch. Which means filtering at least one codestream per product in each group/branch.