### PR TITLE
plugins: Add new 'lint' command

### DIFF
--- a/klp-build.1
+++ b/klp-build.1
@@ -241,6 +241,23 @@ branch in the repository.
 Overwrite existing livepatches and branches in the repository.
 .RE
 .TP
+.B lint
+Verifies the code quality of the commited livepatches.
+More specifically,
+.B lint
+compiles with
+.BR gcc (1)
+the livepatch for a given codestream and reports back
+the number of errors, warnings and unrelated errors found
+during compilation and linking.
+.RS 7
+.TP
+.BI --gcc " GCC_VERSION_NUMBER"
+Use a specific
+.BR gcc (1)
+version (e.g 13, 15...).
+.RE
+.TP
 .B format-patches
 Extract patches from kgraft-patches (see the
 .BR "SEE ALSO" " section)."

--- a/klpbuild/klplib/kgraft.py
+++ b/klpbuild/klplib/kgraft.py
@@ -7,9 +7,14 @@ import logging
 import subprocess
 import os
 import re
+import glob
+import tarfile
+import shutil
 
+from pathlib import Path
 from klpbuild.klplib.config import get_user_path
 from klpbuild.klplib.utils import get_workdir
+from klpbuild.klplib.config import get_user_settings
 
 TREE_NAME = "kgraft"
 __KGR_PATH = ""
@@ -101,6 +106,30 @@ def create_lp_branch(branch, base="origin/master-livepatch"):
             )
 
 
+def create_release_branch(cs, lp_branch, prefix):
+    '''
+        Creates the release branch for a given livepatch.
+        A release branch is based in the product branch +
+        the new livepatch source code. If compiled and built, it
+        will generate a working livepatch kernel module.
+
+        Returns:
+            The release branch name if it was successfully created.
+            'None' otherwise.
+    '''
+    product_branch = cs.get_full_product_name()
+    release_branch = f"{prefix}/{product_branch}/{str(lp_branch)}"
+
+    try:
+        fetch_branch(product_branch)
+        create_lp_branch(release_branch, lp_branch)
+        rebase_lp_branch(release_branch, product_branch)
+    except subprocess.CalledProcessError:
+        release_branch = None
+
+    return release_branch
+
+
 def commit_lp_changes(lp_name):
     subprocess.check_output(
             ["git", "add", "."],
@@ -113,3 +142,68 @@ def commit_lp_changes(lp_name):
             cwd=get_kgraft(),
             stderr=subprocess.STDOUT,
             )
+
+
+def tar_up(prj_path, version=None):
+    '''
+        Run the tar-up script found in all kgraft branches.
+        The script will archive the livepatches and prepare the files
+        for building the kernel module.
+    '''
+    kgr_path = get_kgraft()
+
+    if prj_path.exists():
+        shutil.rmtree(prj_path)
+
+    if version:
+        with open(Path(kgr_path, "scripts", "release-version.sh"), "w") as f:
+            f.write(f"RELEASE={version}")
+
+    subprocess.check_output(
+        ["bash", "./scripts/tar-up.sh", "-d", str(prj_path)],
+        cwd=kgr_path,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def make(prj_path, cs, gcc_version, gcc_log):
+    '''
+        Compile the livepatch kernel module for the given
+        codestream. Use default `gcc` if no specific version
+        is provided.
+
+        Return:
+            0 if succeeded. > 0 otherwise.
+    '''
+    workers = int(get_user_settings("workers"))
+    sdir = cs.get_src_dir()
+    odir = cs.get_obj_dir()
+
+    # Use gcc-7 for older kernel (12.5, 15.4 and 15.5)
+    if not cs.needs_ibt():
+        gcc_version = 7
+
+    cc = f"gcc-{gcc_version}" if gcc_version else "gcc"
+
+    tar_up(prj_path)
+
+    # Before compiling first extract all the bsc tar files.
+    for tar in glob.glob(f"{prj_path}/*.tar.bz2"):
+        with tarfile.open(name=tar, mode="r:bz2", ignore_zeros=True) as t:
+             t.extractall(path=prj_path, filter='data')
+
+    with open(gcc_log, "w") as log:
+        err = subprocess.run(
+                ["make",
+                 f"KDIR={sdir}",
+                 f"O={odir}",
+                 f"CC={cc}",
+                 f"-j{workers}"],
+                cwd=prj_path,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True, check=False)
+
+    shutil.rmtree(prj_path)
+
+    return err.returncode

--- a/klpbuild/plugins/lint.py
+++ b/klpbuild/plugins/lint.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Copyright (C) 2026 SUSE
+# Author: Fernando Gonzalez <fernando.gonzalez@suse.com>
+
+import logging
+from pathlib import Path
+
+from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
+from klpbuild.klplib.supported import get_supported_codestreams
+from klpbuild.klplib.utils import (filter_codestreams,
+                                   filter_fast,
+                                   get_cs_branch)
+from klpbuild.klplib.kgraft import (create_release_branch,
+                                    find_lp_branches,
+                                    delete_lp_branches,
+                                    make,
+                                    get_kgraft,
+                                    init_kgraft,
+                                    reset_kgraft)
+
+PLUGIN_CMD = "lint"
+
+def register_argparser(subparser):
+    fmt = subparser.add_parser(
+        PLUGIN_CMD, help="Verify the code quality of the commited livepatches."
+    )
+
+    add_arg_lp_name(fmt)
+    add_arg_lp_filter(fmt)
+    fmt.add_argument("--gcc", type=int, default=0,
+                     help="Use a specific gcc version (e.g 13, 15...)")
+
+
+def gcc_report(log_file, lp_name):
+    errors = 0
+    warns = 0
+    others = 0
+
+    with open(log_file, "r", encoding="utf-8") as file:
+        for l in file:
+            if f"build/{lp_name}" in l:
+                # Any errors related to the lp object
+                if ": error:" in l:
+                    errors += 1
+                if ": warning:" in l:
+                    warns += 1
+            else:
+                # Report any not related errors
+                if ": error:" in l:
+                    others += 1
+
+
+    return errors, warns, others
+
+
+def lint(lp_name, cs_list, gcc_version):
+    init_kgraft()
+
+    for cs in cs_list:
+        lp_branch = get_cs_branch(cs, lp_name, get_kgraft())
+        if not lp_branch:
+            logging.info("%s: No branch found. Skipping.", cs.full_cs_name())
+            continue
+
+        logging.info("%s (%s):", cs.full_cs_name(), lp_branch)
+
+        lint_branch = create_release_branch(cs, lp_branch, "lint")
+        if not lint_branch:
+            logging.info("Failed to create a release branch. Skipping.")
+            continue
+
+        prj_path = Path(cs.get_ccp_dir(lp_name), "build")
+        gcc_log = Path(cs.get_ccp_dir(lp_name), "gcc.log")
+        err = make(prj_path, cs, gcc_version, gcc_log)
+
+        errors, warns, others = gcc_report(gcc_log, lp_name)
+
+        logging.info(" %s (%d warnings, %d errors, %d others)",
+                     "OK" if not err else "BAD",
+                     warns, errors, others)
+
+        if err:
+            logging.info(" Saved in %s", gcc_log)
+
+    br = find_lp_branches(f"lint*{lp_name}*")
+    delete_lp_branches(br)
+
+    reset_kgraft()
+
+
+def run(lp_name, lp_filter, gcc):
+    supported_codestreams = get_supported_codestreams()
+    if lp_filter:
+        filtered_codestreams = filter_codestreams(lp_filter, supported_codestreams)
+    else:
+        filtered_codestreams = filter_fast(lp_name, supported_codestreams)
+
+    lint(lp_name, filtered_codestreams, gcc)

--- a/klpbuild/plugins/push.py
+++ b/klpbuild/plugins/push.py
@@ -7,7 +7,6 @@ import logging
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import sys
 import time
 
@@ -21,9 +20,9 @@ from klpbuild.klplib.utils import (classify_codestreams_str, filter_codestreams,
                                    get_cs_branch)
 from klpbuild.plugins.status import status
 from klpbuild.plugins.commit import commit
-from klpbuild.klplib.kgraft import (create_lp_branch, fetch_branch,
-                                    rebase_lp_branch, find_lp_branches,
-                                    delete_lp_branches, get_kgraft)
+from klpbuild.klplib.kgraft import (create_release_branch,
+                                    find_lp_branches, delete_lp_branches,
+                                    tar_up, get_kgraft)
 
 PLUGIN_CMD = "push"
 
@@ -53,36 +52,7 @@ def create_prj_meta(cs):
            "</project>"
 
 
-def create_push_branch(cs, lp_branch):
-    product_branch = cs.get_full_product_name()
-    push_branch = f"push/{product_branch}/{str(lp_branch)}"
-
-    try:
-        fetch_branch(product_branch)
-        create_lp_branch(push_branch, lp_branch)
-        rebase_lp_branch(push_branch, product_branch)
-    except subprocess.CalledProcessError:
-        # Fallback in case the push_branch cannot be successfully created.
-        # Not meant for building final livepatches.
-        logging.warning("Failed to create branch '%s'. Using instead '%s'.",
-                        push_branch, lp_branch)
-        push_branch = lp_branch
-
-    return push_branch
-
-
-def create_lp_package(osc, lp_name, i, total, cs):
-    kgr_path = get_kgraft()
-    branch = get_cs_branch(cs, lp_name, kgr_path)
-    if not branch:
-        logging.info("Could not find git branch for %s. Skipping.", cs.full_cs_name())
-        return
-
-    # Remove previously created directories
-    prj_path = Path(cs.get_ccp_dir(lp_name), "checkout")
-    if prj_path.exists():
-        shutil.rmtree(prj_path)
-
+def create_osc_prj(osc, lp_name, cs):
     # If the project exists, drop it first
     prj = convert_cs_to_prj(cs, prj_prefix(lp_name, osc))
     delete_project(osc, 0, 0, prj, verbose=False)
@@ -101,9 +71,21 @@ def create_lp_package(osc, lp_name, i, total, cs):
         logging.error(e, str(e))
         raise RuntimeError("") from e
 
-    osc.packages.checkout(prj, "klp", prj_path)
+    return prj
 
-    push_branch = create_push_branch(cs, branch)
+
+def create_lp_package(osc, lp_name, i, total, cs):
+    kgr_path = get_kgraft()
+
+    branch = get_cs_branch(cs, lp_name, kgr_path)
+    if not branch:
+        logging.info("Could not find git branch for %s. Skipping.", cs.full_cs_name())
+        return
+
+    push_branch = create_release_branch(cs, branch, "push")
+    if not push_branch:
+        logging.info("Failed to create a release branch. Skipping.")
+        return
 
     logging.info("(%s/%s) pushing %s using branches %s...",
                  i, total, cs.full_cs_name(), push_branch)
@@ -115,14 +97,13 @@ def create_lp_package(osc, lp_name, i, total, cs):
     if lp_name not in os.listdir(kgr_path):
         logging.warning("Directory %s not found on branch %s", lp_name, branch)
 
-    # Fix RELEASE version
-    with open(Path(kgr_path, "scripts", "release-version.sh"), "w") as f:
-        ver = cs.get_full_product_name().replace("EMBARGO", "")
-        f.write(f"RELEASE={ver}")
+    # Fix RELEASE version and archive the source code
+    ver = cs.get_full_product_name().replace("EMBARGO", "")
+    prj_path = Path(cs.get_ccp_dir(lp_name), "checkout")
+    tar_up(prj_path, ver)
 
-    subprocess.check_output(
-        ["bash", "./scripts/tar-up.sh", "-d", str(prj_path)], stderr=subprocess.STDOUT, cwd=kgr_path
-    )
+    prj = create_osc_prj(osc, lp_name, cs)
+    osc.packages.checkout(prj, "klp", prj_path)
 
     # Add all files to the project, commit the changes and delete the directory.
     for fname in prj_path.iterdir():


### PR DESCRIPTION
The lint command is based on @vmezzela idea of locally compiling livepatches for fast detection of syntax and linking errors.
So, for a given `-n bscxxxx`, `lint` will attempt to compile with `gcc ` all the commited livepatches and report back the number of errors and warnings.


```
> time klp-build lint -n bsc1263927
6.0rtu11 (bsc1263927_6.0rtu11-23_6.0u10-22):
 OK (0 warnings, 0 errors, 0 others)
6.0u10 (bsc1263927_6.0rtu11-23_6.0u10-22):
 OK (0 warnings, 0 errors, 0 others)
12.5u72 (bsc1263927_12.5u72-82):
 OK (0 warnings, 0 errors, 0 others)
15.6u13 (bsc1263927_15.6u13_15.7rtu2_15.7u2):
 OK (0 warnings, 0 errors, 0 others)
15.6u14 (bsc1263927_15.6u14-25_15.7rtu3-14_15.7u3-14):
 OK (0 warnings, 0 errors, 0 others)
15.7rtu3 (bsc1263927_15.6u14-25_15.7rtu3-14_15.7u3-14):
 OK (0 warnings, 0 errors, 0 others)
15.7u3 (bsc1263927_15.6u14-25_15.7rtu3-14_15.7u3-14):
 OK (0 warnings, 0 errors, 0 others)
16.0rtu0 (bsc1263927_16.0rtu0-11_16.0u0-11):
 OK (0 warnings, 0 errors, 0 others)
16.0u0 (bsc1263927_16.0rtu0-11_16.0u0-11):
 OK (0 warnings, 0 errors, 0 others)

real	1m52.114s
```

It's reasonably fast, especially compared to `push`. By default, if `--filter` is not indicated, `lint` will use `fast_filtering` instead of processing all affected codestreams.

Note that this command is not a substitute of `push`. It's meant to be used during development for catching common syntax errors. Also note that, even if unlikely, `lint` may report back false-positives/negatives due to gcc version mismatch.

As a workaround, for such cases there's the `--gcc` option.
`klp-build lint -n bsc1263927 --gcc 14 --filter "15.6u23"`