### PR TITLE
Fix utils.filter_fast test and pylint errors/warnings

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import logging
 
-from pathlib import Path, PurePath
+from pathlib import Path
 from importlib import resources
 
 from klpbuild.klplib.affected_file import AffectedConfig, AffectedFile, AffectedModule, ConfigState

--- a/klpbuild/klplib/data.py
+++ b/klpbuild/klplib/data.py
@@ -5,7 +5,6 @@
 
 import logging
 import shutil
-from pathlib import Path
 
 from klpbuild.klplib.affected_file import AffectedModule
 from klpbuild.klplib.utils import classify_codestreams_str,ARCHS

--- a/klpbuild/klplib/ibs.py
+++ b/klpbuild/klplib/ibs.py
@@ -5,7 +5,6 @@
 
 import concurrent.futures
 import dataclasses
-import errno
 from itertools import repeat
 import logging
 import os
@@ -176,7 +175,7 @@ def validate_livepatch_module(cs, arch, rpm_dir, rpm):
 
 def verify_rpm(rpm_path):
     ret = subprocess.run(["rpm", "-K", "--nosignature", str(rpm_path)],
-                            capture_output=True, text=True)
+                            capture_output=True, text=True, check=False)
     if ret.returncode != 0:
         logging.error("RPM verification failed for %s", rpm_path)
         return False

--- a/klpbuild/plugins/extract.py
+++ b/klpbuild/plugins/extract.py
@@ -21,7 +21,7 @@ from filelock import FileLock
 from natsort import natsorted
 
 from klpbuild.klplib import utils
-from klpbuild.klplib.affected_file import AffectedFile, AffectedModule
+from klpbuild.klplib.affected_file import AffectedFile
 from klpbuild.klplib.cmd import add_arg_lp_name, add_arg_lp_filter
 from klpbuild.klplib.codestreams_data import store_codestreams, get_codestreams_data, get_codestreams_list
 from klpbuild.klplib.config import get_user_settings

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -3,11 +3,12 @@
 # Copyright (C) 2021-2024 SUSE
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com
 
+import concurrent.futures
 import dataclasses
 import logging
-import concurrent.futures
-import tabulate
 from dataclasses import dataclass
+
+import tabulate
 
 from klpbuild.klplib import utils
 from klpbuild.klplib.analysis import (

--- a/klpbuild/plugins/setup.py
+++ b/klpbuild/plugins/setup.py
@@ -5,6 +5,7 @@
 
 import copy
 import logging
+import sys
 
 from natsort import natsorted
 
@@ -252,9 +253,9 @@ def setup_project_files(lp_name, codestreams, full_checks):
             __symbol_check(cs, mod_name, set(mod_info["syms"]), set(mod_info["archs"]), full_checks)
 
         if not cs.files:
-            logging.error(f"%s (%s): No files eligible to be livepatched.", cs.full_cs_name(), cs.kernel)
-            logging.error(f"Try using --file-funcs to specify the affected file and function.")
-            exit(1)
+            logging.error("%s (%s): No files eligible to be livepatched.", cs.full_cs_name(), cs.kernel)
+            logging.error("Try using --file-funcs to specify the affected file and function.")
+            sys.exit(1)
 
     store_codestreams(lp_name, codestreams)
     logging.info("Done. Setup finished.")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "pyelftools",
         "zstandard",
         "python-bugzilla",
-        "python-magic",
+        "file-magic",
         "tabulate",
         "termcolor"
     ],

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -3,8 +3,6 @@
 # Copyright (C) 2025 SUSE
 # Author: Marcos Paulo de Souza <mpdesouza@suse.com>
 
-from datetime import date
-
 from klpbuild.klplib.utils import date_to_days
 from klpbuild.klplib.bugzilla import (get_bug, get_bug_title, get_pending_bugs,
                                       get_bug_data, get_bug_desc, get_bug_prio,

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -13,7 +13,7 @@ def test_scan_all_cs_patched(caplog):
     assert "All supported codestreams are already patched" in caplog.text
 
 
-def test_scan_with_extra_patches(caplog):
+def test_scan_with_extra_patches():
     extra_patch = "patches.suse/net-fix-__dst_negative_advice-race.patch"
     patches, _, _, _ = scan("2022-48801", "", "", False,
                             extra_patches=[extra_patch])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,15 +24,23 @@ def test_group_classify():
         ["15.4u24-26", "15.5u6-9", "15.5u11-14", "15.6u0-10"]
 
 
-def test_filter_fast():
+def test_filter_fast(monkeypatch):
+    monkeypatch.setattr(utils, "get_user_path", lambda entry: None)
+    monkeypatch.setattr(
+        utils,
+        "get_lp_branches",
+        lambda lp_name, git_dir: ["bsc123456_15.2u10-11_15.3u10-12_6.0u0"],
+    )
+
     assert utils.filter_fast(
+        "bsc123456",
         [
             Codestream("6.0u0"),
             Codestream("15.2u10"),
             Codestream("15.2u11"),
             Codestream("15.3u10"),
             Codestream("15.3u12"),
-        ]
+        ],
     ) == [Codestream("6.0u0"), Codestream("15.2u10"), Codestream("15.3u10")]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,7 @@ class FakeCS:
     def lp_out_file(self, lp, f):
         return f"{lp}_{f.replace('/', '_').replace('-', '_')}"
 
-    def get_file_mod(self, f, arch=None):
+    def get_file_mod(self, f):
         # Mirrors Codestream.get_file_mod: returns an AffectedModule, with the
         # same instance returned across calls so cache_obj_path mutations stay
         # visible (matching Codestream.modules.setdefault semantics).


### PR DESCRIPTION
PR #264 didn't update the corresponding test and was failing. The pylint score was below our threshold, so the CI was failing too.