### PR TITLE
klplib/codestream: do not override module_name when gating config is builtin

### DIFF
--- a/klpbuild/klplib/codestream.py
+++ b/klpbuild/klplib/codestream.py
@@ -426,18 +426,20 @@ class Codestream:
         Resolve which kernel object the given file is patched into for ``arch``.
 
         Returns an :class:`AffectedModule` (the codestream's vmlinux singleton
-        when the gating CONFIG is built-in on ``arch``, the designated
-        ``module_name`` entry otherwise). The returned instance is the same one
-        held in :attr:`modules`, so any subsequent path-cache or supportedness
-        updates persist on the codestream.
+        when the file or its gating module CONFIG is built-in on ``arch``, the
+        designated ``module_name`` entry otherwise). The returned instance is
+        the same one held in :attr:`modules`, so any subsequent path-cache or
+        supportedness updates persist on the codestream.
         """
         fdat = self.files[file]
 
         if not arch:
             arch = preferred_arch([self])
 
-        cfg = self.configs[fdat.config_name]
-        if cfg.get_arch(arch) is ConfigState.BUILTIN:
+        cfg = self.configs.get(fdat.config_name)
+        if fdat.module_name == AffectedModule.VMLINUX or (
+            cfg and cfg.is_module_on_any() and cfg.get_arch(arch) is ConfigState.BUILTIN
+        ):
             return self.modules.setdefault(AffectedModule.VMLINUX,
                                            AffectedModule.vmlinux())
         return self.modules.setdefault(fdat.module_name,

--- a/tests/test_codestream.py
+++ b/tests/test_codestream.py
@@ -87,3 +87,40 @@ def test_sle16rt_config():
     cs = Codestream("16.0rtu0", kernel="6.12.0-160000.11")
     config_content = cs.get_config_content()
     assert "CONFIG_RCU_BOOST_DELAY" in config_content
+
+
+def test_get_file_mod_builtin_arch_config():
+    """
+    Ensure get_file_mod returns the specified module when the config is an
+    architecture/builtin config (e.g. CONFIG_X86=y) rather than overriding it
+    with vmlinux.
+    """
+    cs = Codestream.from_data({
+        "name": "15.4u55",
+        "project": "SUSE:Maintenance:44719",
+        "patchid": "",
+        "kernel": "5.14.21-150400.24.222",
+        "eol": "2026-12-31",
+        "archs": ["x86_64"],
+        "files": {
+            "arch/x86/kvm/mmu/mmu.c": {
+                "config_name": "CONFIG_X86",
+                "module_name": "kvm",
+                "affected_symbols": ["paging32_page_fault"],
+                "ibt": False,
+                "dup_symbols": [],
+                "ext_symbols": {},
+                "klpp_symbols": {}
+            }
+        },
+        "modules": {},
+        "configs": {
+            "CONFIG_X86": {"x86_64": "y"}
+        },
+        "required_patches": []
+    })
+
+    mod = cs.get_file_mod("arch/x86/kvm/mmu/mmu.c", "x86_64")
+    assert mod.name == "kvm"
+    assert "kvm" in cs.modules
+    assert "vmlinux" not in cs.modules


### PR DESCRIPTION
When running klp-build setup with a built-in gating configuration option (such as --conf CONFIG_X86 with --module kvm), get_file_mod() would previously observe CONFIG_X86=y and override module_name to vmlinux, discarding the designated module.

Update get_file_mod() to resolve to vmlinux only if fdat.module_name is explicitly vmlinux or if the gating config is a tristate module config (is_module_on_any() is True) that happens to be built-in on the target architecture. This ensures explicit or non-module gating configs do not clobber the specified module_name.