### PR TITLE
 bugzilla: Don't drop 'not affected' bugs 

### DIFF
--- a/klpbuild/klplib/bugzilla.py
+++ b/klpbuild/klplib/bugzilla.py
@@ -209,13 +209,13 @@ def get_kss_watchdog_report(bug):
 
 
 def is_bug_dropped(bug):
-    return (bug.resolution in {"INVALID", "WONTFIX", "DUPLICATED"} or
-            "NO CODESTREAM AFFECTED" in get_kss_watchdog_report(bug))
+    return bug.resolution in {"INVALID", "WONTFIX", "DUPLICATED"}
 
 
 def is_bug_fixed(bug):
     return (bug.resolution == "FIXED" or
-            "NO ACTION NEEDED" in get_kss_watchdog_report(bug))
+            "NO ACTION NEEDED" in get_kss_watchdog_report(bug) or
+            "NO CODESTREAM AFFECTED" in get_kss_watchdog_report(bug))
 
 
 def is_bug_embargoed(bug):

--- a/klpbuild/plugins/scan.py
+++ b/klpbuild/plugins/scan.py
@@ -123,7 +123,7 @@ def scan_job(bug, cve):
     if npatches:
         result.status = f"Fixed({npatches})"
 
-    if dep and "security-team" not in dep.assigned_to:
+    if dep and "security" not in dep.assigned_to:
         result.status = f"Incomplete({npatches})"
 
     if affected_cs:


### PR DESCRIPTION
Bugs marked as 'not affected' by KSS shouldn't be dropped.
Those bugs will be closed, without any backport been done, because
the fixes already exists in the product branches. However, that
doesn't mean all supported codestreams include the fix.

Hence, the correct action is to mark those bugs as fixed.